### PR TITLE
Release v2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) (`<ma
 * #98 Add `--dispatch-decorators` to support suppression of all errors from functions decorated by decorators such as `functools.singledispatch` and `functools.singledispatchmethod`.
 * #99 Add `--overload-decorators` to support generic aliasing of the `typing.overload` decorator.
 
+### Fixed
+* #106 Fix incorrect parsing of multiline docstrings with less than two lines of content, causing incorrect line numbers for yielded errors in Python versions prior to 3.8
+
 ## [v2.5.0]
 ### Added
 * #103 Add `--allow-untyped-nested` to suppress all errors from dynamically typted nested functions. A function is considered dynamically typed if it does not contain any type hints.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
 # Changelog
 Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) (`<major>`.`<minor>`.`<patch>`)
 
+## [v2.6.0]
+### Added
+* #98 Add `--dispatch-decorators` to support suppression of all errors from functions decorated by decorators such as `functools.singledispatch` and `functools.singledispatchmethod`.
+* #99 Add `--overload-decorators` to support generic aliasing of the `typing.overload` decorator.
+
 ## [v2.5.0]
 ### Added
-* #103 add `--allow-untyped-nested` to suppress all errors from dynamically typted nested functions. A function is considered dynamically typed if it does not contain any type hints.
+* #103 Add `--allow-untyped-nested` to suppress all errors from dynamically typted nested functions. A function is considered dynamically typed if it does not contain any type hints.
 
 ## [v2.4.1]
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # flake8-annotations
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/flake8-annotations)](https://pypi.org/project/flake8-annotations/)
 [![PyPI](https://img.shields.io/pypi/v/flake8-annotations)](https://pypi.org/project/flake8-annotations/)
+[![PyPI - License](https://img.shields.io/pypi/l/flake8-annotations?color=magenta)](https://github.com/sco1/flake8-annotations/blob/master/LICENSE)
+[![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
+[![Code style: black](https://img.shields.io/badge/code%20style-black-black)](https://github.com/psf/black)
 
-`flake8-annotations` is a plugin for [Flake8](http://flake8.pycqa.org/en/latest/) that detects the absence of [PEP 3107-style](https://www.python.org/dev/peps/pep-3107/) function annotations and [PEP 484-style](https://www.python.org/dev/peps/pep-0484/#type-comments) type comments  (see: [Caveats](#Caveats-for-PEP-484-style-Type-Comments)).
+`flake8-annotations` is a plugin for [Flake8](http://flake8.pycqa.org/en/latest/) that detects the absence of [PEP 3107-style](https://www.python.org/dev/peps/pep-3107/) function annotations and [PEP 484-style](https://www.python.org/dev/peps/pep-0484/#type-comments) type comments (see: [Caveats](#Caveats-for-PEP-484-style-Type-Comments)).
 
 What this won't do: Check variable annotations (see: [PEP 526](https://www.python.org/dev/peps/pep-0526/)), respect stub files, or replace [mypy](http://mypy-lang.org/).
 
@@ -96,7 +99,7 @@ Decorators are matched based on their attribute name. For example, `"singledispa
 
 **NOTE:** Deeper imports, such as `a.b.singledispatch` are not supported.
 
-See [Generic Functions](#generic-functions) for additional information.
+See: [Generic Functions](#generic-functions) for additional information.
 
 Default: `"singledispatch, singledispatchmethod"`
 
@@ -110,7 +113,7 @@ Decorators are matched based on their attribute name. For example, `"overload"` 
 
 **NOTE:** Deeper imports, such as `a.b.overload` are not supported.
 
-See [The `typing.overload` Decorator](#the-typingoverload-decorator) for additional information.
+See: [The `typing.overload` Decorator](#the-typingoverload-decorator) for additional information.
 
 Default: `"overload"`
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Decorators are matched based on their attribute name. For example, `"singledispa
   * `import functools as fnctls; @fnctls.singledispatch`
   * `from functools import singledispatch; @singledispatch`
 
-**NOTE:** Callable decorators are currently not considered.
+**NOTE:** Deeper imports, such as `a.b.singledispatch` are not supported.
 
 See [Generic Functions](#generic-functions) for additional information.
 
@@ -108,7 +108,7 @@ Decorators are matched based on their attribute name. For example, `"overload"` 
   * `import typing as t; @t.overload`
   * `from typing import overload; @overload`
 
-**NOTE:** Callable decorators are currently not considered.
+**NOTE:** Deeper imports, such as `a.b.overload` are not supported.
 
 See [The `typing.overload` Decorator](#the-typingoverload-decorator) for additional information.
 

--- a/flake8_annotations/__init__.py
+++ b/flake8_annotations/__init__.py
@@ -21,7 +21,7 @@ __version__ = "2.6.0"
 
 # The order of AST_ARG_TYPES must match Python's grammar
 # See: https://docs.python.org/3/library/ast.html#abstract-grammar
-AST_ARG_TYPES = ("args", "vararg", "kwonlyargs", "kwarg")
+AST_ARG_TYPES: Tuple[str, ...] = ("args", "vararg", "kwonlyargs", "kwarg")
 if PY_GTE_38:
     # Positional-only args introduced in Python 3.8
     # If posonlyargs are present, they will be before other argument types
@@ -168,11 +168,11 @@ class Function:
         """Determine if the function is dynamically typed, defined as completely lacking hints."""
         return not any(arg.has_type_annotation for arg in self.args)
 
-    def get_missed_annotations(self) -> List:
+    def get_missed_annotations(self) -> List[Argument]:
         """Provide a list of arguments with missing type annotations."""
         return [arg for arg in self.args if not arg.has_type_annotation]
 
-    def get_annotated_arguments(self) -> List:
+    def get_annotated_arguments(self) -> List[Argument]:
         """Provide a list of arguments with type annotations."""
         return [arg for arg in self.args if arg.has_type_annotation]
 

--- a/flake8_annotations/__init__.py
+++ b/flake8_annotations/__init__.py
@@ -35,6 +35,16 @@ AST_DECORATOR_NODES = Union[ast.Attribute, ast.Call, ast.Name]
 class Argument:
     """Represent a function argument & its metadata."""
 
+    __slots__ = [
+        "argname",
+        "lineno",
+        "col_offset",
+        "annotation_type",
+        "has_type_annotation",
+        "has_3107_annotation",
+        "has_type_comment",
+    ]
+
     def __init__(
         self,
         argname: str,
@@ -102,6 +112,21 @@ class Function:
     tool, both will be referred to as functions outside of any class-specific context. This also
     aligns with ast's naming convention.
     """
+
+    __slots__ = [
+        "name",
+        "lineno",
+        "col_offset",
+        "function_type",
+        "is_class_method",
+        "class_decorator_type",
+        "is_return_annotated",
+        "has_type_comment",
+        "has_only_none_returns",
+        "is_nested",
+        "decorator_list",
+        "args",
+    ]
 
     def __init__(
         self,

--- a/flake8_annotations/__init__.py
+++ b/flake8_annotations/__init__.py
@@ -151,12 +151,12 @@ class Function:
         """Provide a list of arguments with type annotations."""
         return [arg for arg in self.args if arg.has_type_annotation]
 
-    def is_overload_decorated(self, overload_decorators: Set[str]) -> bool:
+    def has_decorator(self, check_decorators: Set[str]) -> bool:
         """
-        Determine whether the provided function node is decorated by `typing.overload`.
+        Determine whether the function node is decorated by any of the provided decorators.
 
-        Decorator matching is done against the provided `overload_decorators` set, allowing the user
-        to specify any expected aliasing in their flake8 configuration options. Decorators are
+        Decorator matching is done against the provided `check_decorators` set, allowing the user
+        to specify any expected aliasing in the relevant flake8 configuration option. Decorators are
         assumed to be either a module attribute (e.g. `@typing.overload`) or name
         (e.g. `@overload`), and never as a callable (`@typing.overload()`). For the case of a module
         attribute, only the attribute is checked against `overload_decorators`.
@@ -166,10 +166,10 @@ class Function:
         # (e.g. `@typing.overload`)
         for decorator in self.decorator_list:
             if isinstance(decorator, ast.Name):
-                if decorator.id in overload_decorators:
+                if decorator.id in check_decorators:
                     return True
-            elif isinstance(decorator, ast.Attribute):
-                if decorator.attr in overload_decorators:
+            elif isinstance(decorator, ast.Attribute):  # pragma: no branch
+                if decorator.attr in check_decorators:
                     return True
         else:
             return False

--- a/flake8_annotations/__init__.py
+++ b/flake8_annotations/__init__.py
@@ -329,24 +329,24 @@ class Function:
         if node.lineno == node.body[0].lineno:
             return Function._single_line_colon_seeker(node, lines[node.lineno - 1])
 
-        def_end_lineno = node.body[0].lineno - 1
-
         # With Python < 3.8, the function node includes the docstring & the body does not, so
         # we have rewind through any docstrings, if present, before looking for the def colon
+        # We should end up with lines[def_end_lineno - 1] having the colon
+        def_end_lineno = node.body[0].lineno
         if not PY_GTE_38:
-            # This list index is a little funky, since we've already subtracted 1 outside of this
-            # context, we can leave it as-is since it will index the list to the line prior to where
-            # the function node's body begins.
             # If the docstring is on one line then no rewinding is necessary.
-            n_triple_quotes = lines[def_end_lineno].count('"""')
+            n_triple_quotes = lines[def_end_lineno - 1].count('"""')
             if n_triple_quotes == 1:  # pragma: no branch
                 # Docstring closure, rewind until the opening is found & take the line prior
                 while True:
                     def_end_lineno -= 1
                     if '"""' in lines[def_end_lineno - 1]:
                         # Docstring has closed
-                        def_end_lineno -= 1
                         break
+
+        # Once we've gotten here, we've found the line where the docstring begins, so we have
+        # to step up one more line to get to the close of the def
+        def_end_lineno -= 1
 
         # Use str.rfind() to account for annotations on the same line, definition closure should
         # be the last : on the line

--- a/flake8_annotations/__init__.py
+++ b/flake8_annotations/__init__.py
@@ -17,7 +17,7 @@ else:
 
     PY_GTE_38 = False
 
-__version__ = "2.5.0"
+__version__ = "2.6.0"
 
 # The order of AST_ARG_TYPES must match Python's grammar
 # See: https://docs.python.org/3/library/ast.html#abstract-grammar

--- a/flake8_annotations/checker.py
+++ b/flake8_annotations/checker.py
@@ -81,7 +81,7 @@ class TypeHintChecker:
                     # Skip yielding errors from dynamically typed nested functions
                     continue
 
-            # Skip yielding errors for configured dispatch functions, such as
+            # Skip yielding errors for configured dispatch functions, such as (by default)
             # `functools.singledispatch` and `functools.singledispatchmethod`
             if function.has_decorator(self.dispatch_decorators):
                 continue

--- a/flake8_annotations/checker.py
+++ b/flake8_annotations/checker.py
@@ -81,6 +81,11 @@ class TypeHintChecker:
                     # Skip yielding errors from dynamically typed nested functions
                     continue
 
+            # Skip yielding errors for configured dispatch functions, such as
+            # `functools.singledispatch` and `functools.singledispatchmethod`
+            if function.has_decorator(self.dispatch_decorators):
+                continue
+
             # Create sentinels to check for mixed hint styles
             if function.has_type_comment:
                 has_type_comment = True
@@ -109,7 +114,7 @@ class TypeHintChecker:
                 continue
 
             # If it's not, and it is overload decorated, store it for the next iteration
-            if function.is_overload_decorated(self.overload_decorators):
+            if function.has_decorator(self.overload_decorators):
                 last_overload_decorated_function_name = function.name
 
             # Yield explicit errors for arguments that are missing annotations

--- a/flake8_annotations/checker.py
+++ b/flake8_annotations/checker.py
@@ -279,7 +279,7 @@ def _return_error_classifier(
     is_class_method: bool,
     class_decorator_type: enums.ClassDecoratorType,
     function_type: enums.FunctionType,
-) -> error_codes.Error:
+) -> t.Type[error_codes.Error]:
     """Classify return type annotation error."""
     # Decorated class methods (@classmethod, @staticmethod) have a higher priority than the rest
     if is_class_method:
@@ -304,7 +304,7 @@ def _argument_error_classifier(
     is_first_arg: bool,
     class_decorator_type: enums.ClassDecoratorType,
     annotation_type: enums.AnnotationType,
-) -> error_codes.Error:
+) -> t.Type[error_codes.Error]:
     """Classify argument type annotation error."""
     # Check for regular class methods and @classmethod, @staticmethod is deferred to final check
     if is_class_method:

--- a/flake8_annotations/checker.py
+++ b/flake8_annotations/checker.py
@@ -109,7 +109,7 @@ class TypeHintChecker:
                 continue
 
             # If it's not, and it is overload decorated, store it for the next iteration
-            if function.is_overload_decorated:
+            if function.is_overload_decorated(self.overload_decorators):
                 last_overload_decorated_function_name = function.name
 
             # Yield explicit errors for arguments that are missing annotations

--- a/flake8_annotations/checker.py
+++ b/flake8_annotations/checker.py
@@ -1,6 +1,6 @@
+import typing as t
 from argparse import Namespace
 from functools import lru_cache
-from typing import Generator, List, Optional, Set, Tuple
 
 from flake8.options.manager import OptionManager
 from flake8_annotations import (
@@ -20,7 +20,7 @@ if PY_GTE_38:
 else:
     from typed_ast import ast3 as ast
 
-FORMATTED_ERROR = Tuple[int, int, str, error_codes.Error]
+FORMATTED_ERROR = t.Tuple[int, int, str, t.Type[t.Any]]
 
 _DEFAULT_DISPATCH_DECORATORS = [
     "singledispatch",
@@ -38,7 +38,7 @@ class TypeHintChecker:
     name = "flake8-annotations"
     version = __version__
 
-    def __init__(self, tree: ast.Module, lines: List[str]):
+    def __init__(self, tree: t.Optional[ast.Module], lines: t.List[str]):
         # Request `tree` in order to ensure flake8 will run the plugin, even though we don't use it
         # Request `lines` here and join to allow for correct handling of input from stdin
         self.lines = lines
@@ -50,10 +50,10 @@ class TypeHintChecker:
         self.allow_untyped_defs: bool
         self.allow_untyped_nested: bool
         self.mypy_init_return: bool
-        self.dispatch_decorators: Set[str]
-        self.overload_decorators: Set[str]
+        self.dispatch_decorators: t.Set[str]
+        self.overload_decorators: t.Set[str]
 
-    def run(self) -> Generator[FORMATTED_ERROR, None, None]:
+    def run(self) -> t.Generator[FORMATTED_ERROR, None, None]:
         """
         This method is called by flake8 to perform the actual check(s) on the source code.
 
@@ -66,7 +66,7 @@ class TypeHintChecker:
         # Keep track of the last encountered function decorated by `typing.overload`, if any.
         # Per the `typing` module documentation, a series of overload-decorated definitions must be
         # followed by exactly one non-overload-decorated definition of the same function.
-        last_overload_decorated_function_name: Optional[str] = None
+        last_overload_decorated_function_name: t.Optional[str] = None
 
         # Iterate over the arguments with missing type hints, by function, and yield linting errors
         # to flake8
@@ -228,7 +228,7 @@ class TypeHintChecker:
         cls.allow_untyped_nested = options.allow_untyped_nested
         cls.mypy_init_return = options.mypy_init_return
 
-        # Store decorator lists as sets for better lookup
+        # Store decorator lists as sets for easier lookup
         cls.dispatch_decorators = set(options.dispatch_decorators)
         cls.overload_decorators = set(options.overload_decorators)
 

--- a/flake8_annotations/checker.py
+++ b/flake8_annotations/checker.py
@@ -201,8 +201,8 @@ class TypeHintChecker:
             parse_from_config=True,
             comma_separated_list=True,
             help=(
-                "List of decorators flake8-annotations should consider as dispatch decorators. "
-                "(Default: %default)"
+                "Comma-separated list of decorators flake8-annotations should consider as dispatch "
+                "decorators. (Default: %default)"
             ),
         )
 
@@ -214,8 +214,8 @@ class TypeHintChecker:
             parse_from_config=True,
             comma_separated_list=True,
             help=(
-                "List of decorators flake8-annotations should consider as typing.overload "
-                "decorators. (Default: %default)"
+                "Comma-separated list of decorators flake8-annotations should consider as "
+                "typing.overload decorators. (Default: %default)"
             ),
         )
 

--- a/flake8_annotations/error_codes.py
+++ b/flake8_annotations/error_codes.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Type
+from typing import Any, Tuple, Type
 
 from flake8_annotations import Argument, Function, checker
 
@@ -22,7 +22,7 @@ class Error:
         """Set error metadata from the input Function object."""
         return cls(function.name, function.lineno, function.col_offset)
 
-    def to_flake8(self) -> Tuple[int, int, str, Type]:
+    def to_flake8(self) -> Tuple[int, int, str, Type[Any]]:
         """
         Format the Error into what Flake8 is expecting.
 
@@ -40,7 +40,7 @@ class ANN001(Error):
         self.lineno = lineno
         self.col_offset = col_offset
 
-    def to_flake8(self) -> Tuple[int, int, str, Type]:
+    def to_flake8(self) -> Tuple[int, int, str, Type[Any]]:
         """Overload super's formatter so we can include argname in the output."""
         return (
             self.lineno,
@@ -57,7 +57,7 @@ class ANN002(Error):
         self.lineno = lineno
         self.col_offset = col_offset
 
-    def to_flake8(self) -> Tuple[int, int, str, Type]:
+    def to_flake8(self) -> Tuple[int, int, str, Type[Any]]:
         """Overload super's formatter so we can include argname in the output."""
         return (
             self.lineno,
@@ -74,7 +74,7 @@ class ANN003(Error):
         self.lineno = lineno
         self.col_offset = col_offset
 
-    def to_flake8(self) -> Tuple[int, int, str, Type]:
+    def to_flake8(self) -> Tuple[int, int, str, Type[Any]]:
         """Overload super's formatter so we can include argname in the output."""
         return (
             self.lineno,

--- a/poetry.lock
+++ b/poetry.lock
@@ -77,7 +77,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "coverage"
-version = "5.3.1"
+version = "5.5"
 description = "Code coverage measurement for Python"
 category = "dev"
 optional = false
@@ -126,7 +126,7 @@ pyflakes = ">=2.2.0,<2.3.0"
 
 [[package]]
 name = "flake8-bugbear"
-version = "20.11.1"
+version = "21.3.1"
 description = "A plugin for flake8 finding likely bugs and design problems in your program. Contains warnings that don't belong in pyflakes and pycodestyle."
 category = "dev"
 optional = false
@@ -207,33 +207,34 @@ importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 
 [[package]]
 name = "identify"
-version = "1.5.11"
+version = "2.1.0"
 description = "File identification library for Python"
 category = "dev"
 optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
+python-versions = ">=3.6.1"
 
 [package.extras]
 license = ["editdistance"]
 
 [[package]]
 name = "importlib-metadata"
-version = "2.1.1"
+version = "3.7.0"
 description = "Read metadata from Python packages"
 category = "main"
 optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+python-versions = ">=3.6"
 
 [package.dependencies]
+typing-extensions = {version = ">=3.6.4", markers = "python_version < \"3.8\""}
 zipp = ">=0.5"
 
 [package.extras]
-docs = ["sphinx", "rst.linker"]
-testing = ["packaging", "pep517", "unittest2", "importlib-resources (>=1.3)"]
+docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
+testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "pytest-enabler", "packaging", "pep517", "pyfakefs", "flufl.flake8", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
 
 [[package]]
 name = "importlib-resources"
-version = "4.1.1"
+version = "5.1.2"
 description = "Read resources from Python packages"
 category = "dev"
 optional = false
@@ -243,8 +244,8 @@ python-versions = ">=3.6"
 zipp = {version = ">=0.4", markers = "python_version < \"3.8\""}
 
 [package.extras]
-docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "jaraco.test (>=3.2.0)", "pytest-black (>=0.3.7)", "pytest-mypy"]
+docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
+testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "pytest-enabler", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [[package]]
 name = "iniconfig"
@@ -291,7 +292,7 @@ python-versions = "*"
 
 [[package]]
 name = "packaging"
-version = "20.8"
+version = "20.9"
 description = "Core utilities for Python packages"
 category = "dev"
 optional = false
@@ -335,7 +336,7 @@ dev = ["pre-commit", "tox"]
 
 [[package]]
 name = "pre-commit"
-version = "2.9.3"
+version = "2.10.1"
 description = "A framework for managing and maintaining multi-language pre-commit hooks."
 category = "dev"
 optional = false
@@ -396,7 +397,7 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "pytest"
-version = "6.2.1"
+version = "6.2.2"
 description = "pytest: simple powerful testing with Python"
 category = "dev"
 optional = false
@@ -432,14 +433,14 @@ test = ["tox"]
 
 [[package]]
 name = "pytest-cov"
-version = "2.10.1"
+version = "2.11.1"
 description = "Pytest plugin for measuring coverage."
 category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [package.dependencies]
-coverage = ">=4.4"
+coverage = ">=5.2.1"
 pytest = ">=4.6"
 
 [package.extras]
@@ -447,11 +448,11 @@ testing = ["fields", "hunter", "process-tests (==2.0.2)", "six", "pytest-xdist",
 
 [[package]]
 name = "pyyaml"
-version = "5.3.1"
+version = "5.4.1"
 description = "YAML parser and emitter for Python"
 category = "dev"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 
 [[package]]
 name = "regex"
@@ -471,8 +472,8 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "snowballstemmer"
-version = "2.0.0"
-description = "This package provides 26 stemmers for 25 languages generated from Snowball algorithms."
+version = "2.1.0"
+description = "This package provides 29 stemmers for 28 languages generated from Snowball algorithms."
 category = "dev"
 optional = false
 python-versions = "*"
@@ -487,7 +488,7 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "tox"
-version = "3.20.1"
+version = "3.23.0"
 description = "tox is a generic virtualenv management and test command line tool"
 category = "dev"
 optional = false
@@ -496,7 +497,7 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 [package.dependencies]
 colorama = {version = ">=0.4.1", markers = "platform_system == \"Windows\""}
 filelock = ">=3.0.0"
-importlib-metadata = {version = ">=0.12,<3", markers = "python_version < \"3.8\""}
+importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 packaging = ">=14"
 pluggy = ">=0.12.0"
 py = ">=1.4.17"
@@ -506,7 +507,7 @@ virtualenv = ">=16.0.0,<20.0.0 || >20.0.0,<20.0.1 || >20.0.1,<20.0.2 || >20.0.2,
 
 [package.extras]
 docs = ["pygments-github-lexers (>=0.0.5)", "sphinx (>=2.0.0)", "sphinxcontrib-autoprogram (>=0.1.5)", "towncrier (>=18.5.0)"]
-testing = ["flaky (>=3.4.0)", "freezegun (>=0.3.11)", "pathlib2 (>=2.3.3)", "psutil (>=5.6.1)", "pytest (>=4.0.0)", "pytest-cov (>=2.5.1)", "pytest-mock (>=1.10.0)", "pytest-randomly (>=1.0.0)", "pytest-xdist (>=1.22.2)"]
+testing = ["flaky (>=3.4.0)", "freezegun (>=0.3.11)", "psutil (>=5.6.1)", "pytest (>=4.0.0)", "pytest-cov (>=2.5.1)", "pytest-mock (>=1.10.0)", "pytest-randomly (>=1.0.0)", "pytest-xdist (>=1.22.2)", "pathlib2 (>=2.3.3)"]
 
 [[package]]
 name = "typed-ast"
@@ -520,13 +521,13 @@ python-versions = "*"
 name = "typing-extensions"
 version = "3.7.4.3"
 description = "Backported and Experimental Type Hints for Python 3.5+"
-category = "dev"
+category = "main"
 optional = false
 python-versions = "*"
 
 [[package]]
 name = "virtualenv"
-version = "20.2.2"
+version = "20.4.2"
 description = "Virtual Python Environment builder"
 category = "dev"
 optional = false
@@ -542,24 +543,24 @@ six = ">=1.9.0,<2"
 
 [package.extras]
 docs = ["proselint (>=0.10.2)", "sphinx (>=3)", "sphinx-argparse (>=0.2.5)", "sphinx-rtd-theme (>=0.4.3)", "towncrier (>=19.9.0rc1)"]
-testing = ["coverage (>=4)", "coverage-enable-subprocess (>=1)", "flaky (>=3)", "pytest (>=4)", "pytest-env (>=0.6.2)", "pytest-freezegun (>=0.4.1)", "pytest-mock (>=2)", "pytest-randomly (>=1)", "pytest-timeout (>=1)", "pytest-xdist (>=1.31.0)", "packaging (>=20.0)", "xonsh (>=0.9.16)"]
+testing = ["coverage (>=4)", "coverage-enable-subprocess (>=1)", "flaky (>=3)", "pytest (>=4)", "pytest-env (>=0.6.2)", "pytest-freezegun (>=0.4.1)", "pytest-mock (>=2)", "pytest-randomly (>=1)", "pytest-timeout (>=1)", "packaging (>=20.0)", "xonsh (>=0.9.16)"]
 
 [[package]]
 name = "zipp"
-version = "3.4.0"
+version = "3.4.1"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.extras]
-docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "jaraco.test (>=3.2.0)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
+docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
+testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "pytest-enabler", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6.1"
-content-hash = "4b36819f1b33b5f9d1e584a7a4af827f91de863832c52105e53cad7f77025755"
+content-hash = "bb138a8793d10e6520ea4290c7289aa21f3871e75fd8e674e8cb370ace5a8d2f"
 
 [metadata.files]
 appdirs = [
@@ -591,55 +592,58 @@ colorama = [
     {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
 ]
 coverage = [
-    {file = "coverage-5.3.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:fabeeb121735d47d8eab8671b6b031ce08514c86b7ad8f7d5490a7b6dcd6267d"},
-    {file = "coverage-5.3.1-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:7e4d159021c2029b958b2363abec4a11db0ce8cd43abb0d9ce44284cb97217e7"},
-    {file = "coverage-5.3.1-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:378ac77af41350a8c6b8801a66021b52da8a05fd77e578b7380e876c0ce4f528"},
-    {file = "coverage-5.3.1-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:e448f56cfeae7b1b3b5bcd99bb377cde7c4eb1970a525c770720a352bc4c8044"},
-    {file = "coverage-5.3.1-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:cc44e3545d908ecf3e5773266c487ad1877be718d9dc65fc7eb6e7d14960985b"},
-    {file = "coverage-5.3.1-cp27-cp27m-win32.whl", hash = "sha256:08b3ba72bd981531fd557f67beee376d6700fba183b167857038997ba30dd297"},
-    {file = "coverage-5.3.1-cp27-cp27m-win_amd64.whl", hash = "sha256:8dacc4073c359f40fcf73aede8428c35f84639baad7e1b46fce5ab7a8a7be4bb"},
-    {file = "coverage-5.3.1-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:ee2f1d1c223c3d2c24e3afbb2dd38be3f03b1a8d6a83ee3d9eb8c36a52bee899"},
-    {file = "coverage-5.3.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:9a9d4ff06804920388aab69c5ea8a77525cf165356db70131616acd269e19b36"},
-    {file = "coverage-5.3.1-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:782a5c7df9f91979a7a21792e09b34a658058896628217ae6362088b123c8500"},
-    {file = "coverage-5.3.1-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:fda29412a66099af6d6de0baa6bd7c52674de177ec2ad2630ca264142d69c6c7"},
-    {file = "coverage-5.3.1-cp35-cp35m-macosx_10_9_x86_64.whl", hash = "sha256:f2c6888eada180814b8583c3e793f3f343a692fc802546eed45f40a001b1169f"},
-    {file = "coverage-5.3.1-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:8f33d1156241c43755137288dea619105477961cfa7e47f48dbf96bc2c30720b"},
-    {file = "coverage-5.3.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:b239711e774c8eb910e9b1ac719f02f5ae4bf35fa0420f438cdc3a7e4e7dd6ec"},
-    {file = "coverage-5.3.1-cp35-cp35m-manylinux2010_i686.whl", hash = "sha256:f54de00baf200b4539a5a092a759f000b5f45fd226d6d25a76b0dff71177a714"},
-    {file = "coverage-5.3.1-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:be0416074d7f253865bb67630cf7210cbc14eb05f4099cc0f82430135aaa7a3b"},
-    {file = "coverage-5.3.1-cp35-cp35m-win32.whl", hash = "sha256:c46643970dff9f5c976c6512fd35768c4a3819f01f61169d8cdac3f9290903b7"},
-    {file = "coverage-5.3.1-cp35-cp35m-win_amd64.whl", hash = "sha256:9a4f66259bdd6964d8cf26142733c81fb562252db74ea367d9beb4f815478e72"},
-    {file = "coverage-5.3.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:c6e5174f8ca585755988bc278c8bb5d02d9dc2e971591ef4a1baabdf2d99589b"},
-    {file = "coverage-5.3.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:3911c2ef96e5ddc748a3c8b4702c61986628bb719b8378bf1e4a6184bbd48fe4"},
-    {file = "coverage-5.3.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:c5ec71fd4a43b6d84ddb88c1df94572479d9a26ef3f150cef3dacefecf888105"},
-    {file = "coverage-5.3.1-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:f51dbba78d68a44e99d484ca8c8f604f17e957c1ca09c3ebc2c7e3bbd9ba0448"},
-    {file = "coverage-5.3.1-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:a2070c5affdb3a5e751f24208c5c4f3d5f008fa04d28731416e023c93b275277"},
-    {file = "coverage-5.3.1-cp36-cp36m-win32.whl", hash = "sha256:535dc1e6e68fad5355f9984d5637c33badbdc987b0c0d303ee95a6c979c9516f"},
-    {file = "coverage-5.3.1-cp36-cp36m-win_amd64.whl", hash = "sha256:a4857f7e2bc6921dbd487c5c88b84f5633de3e7d416c4dc0bb70256775551a6c"},
-    {file = "coverage-5.3.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:fac3c432851038b3e6afe086f777732bcf7f6ebbfd90951fa04ee53db6d0bcdd"},
-    {file = "coverage-5.3.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:cd556c79ad665faeae28020a0ab3bda6cd47d94bec48e36970719b0b86e4dcf4"},
-    {file = "coverage-5.3.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:a66ca3bdf21c653e47f726ca57f46ba7fc1f260ad99ba783acc3e58e3ebdb9ff"},
-    {file = "coverage-5.3.1-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:ab110c48bc3d97b4d19af41865e14531f300b482da21783fdaacd159251890e8"},
-    {file = "coverage-5.3.1-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:e52d3d95df81c8f6b2a1685aabffadf2d2d9ad97203a40f8d61e51b70f191e4e"},
-    {file = "coverage-5.3.1-cp37-cp37m-win32.whl", hash = "sha256:fa10fee7e32213f5c7b0d6428ea92e3a3fdd6d725590238a3f92c0de1c78b9d2"},
-    {file = "coverage-5.3.1-cp37-cp37m-win_amd64.whl", hash = "sha256:ce6f3a147b4b1a8b09aae48517ae91139b1b010c5f36423fa2b866a8b23df879"},
-    {file = "coverage-5.3.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:93a280c9eb736a0dcca19296f3c30c720cb41a71b1f9e617f341f0a8e791a69b"},
-    {file = "coverage-5.3.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:3102bb2c206700a7d28181dbe04d66b30780cde1d1c02c5f3c165cf3d2489497"},
-    {file = "coverage-5.3.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:8ffd4b204d7de77b5dd558cdff986a8274796a1e57813ed005b33fd97e29f059"},
-    {file = "coverage-5.3.1-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:a607ae05b6c96057ba86c811d9c43423f35e03874ffb03fbdcd45e0637e8b631"},
-    {file = "coverage-5.3.1-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:3a3c3f8863255f3c31db3889f8055989527173ef6192a283eb6f4db3c579d830"},
-    {file = "coverage-5.3.1-cp38-cp38-win32.whl", hash = "sha256:ff1330e8bc996570221b450e2d539134baa9465f5cb98aff0e0f73f34172e0ae"},
-    {file = "coverage-5.3.1-cp38-cp38-win_amd64.whl", hash = "sha256:3498b27d8236057def41de3585f317abae235dd3a11d33e01736ffedb2ef8606"},
-    {file = "coverage-5.3.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:ceb499d2b3d1d7b7ba23abe8bf26df5f06ba8c71127f188333dddcf356b4b63f"},
-    {file = "coverage-5.3.1-cp39-cp39-manylinux1_i686.whl", hash = "sha256:3b14b1da110ea50c8bcbadc3b82c3933974dbeea1832e814aab93ca1163cd4c1"},
-    {file = "coverage-5.3.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:76b2775dda7e78680d688daabcb485dc87cf5e3184a0b3e012e1d40e38527cc8"},
-    {file = "coverage-5.3.1-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:cef06fb382557f66d81d804230c11ab292d94b840b3cb7bf4450778377b592f4"},
-    {file = "coverage-5.3.1-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:6f61319e33222591f885c598e3e24f6a4be3533c1d70c19e0dc59e83a71ce27d"},
-    {file = "coverage-5.3.1-cp39-cp39-win32.whl", hash = "sha256:cc6f8246e74dd210d7e2b56c76ceaba1cc52b025cd75dbe96eb48791e0250e98"},
-    {file = "coverage-5.3.1-cp39-cp39-win_amd64.whl", hash = "sha256:2757fa64e11ec12220968f65d086b7a29b6583d16e9a544c889b22ba98555ef1"},
-    {file = "coverage-5.3.1-pp36-none-any.whl", hash = "sha256:723d22d324e7997a651478e9c5a3120a0ecbc9a7e94071f7e1954562a8806cf3"},
-    {file = "coverage-5.3.1-pp37-none-any.whl", hash = "sha256:c89b558f8a9a5a6f2cfc923c304d49f0ce629c3bd85cb442ca258ec20366394c"},
-    {file = "coverage-5.3.1.tar.gz", hash = "sha256:38f16b1317b8dd82df67ed5daa5f5e7c959e46579840d77a67a4ceb9cef0a50b"},
+    {file = "coverage-5.5-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:b6d534e4b2ab35c9f93f46229363e17f63c53ad01330df9f2d6bd1187e5eaacf"},
+    {file = "coverage-5.5-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:b7895207b4c843c76a25ab8c1e866261bcfe27bfaa20c192de5190121770672b"},
+    {file = "coverage-5.5-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:c2723d347ab06e7ddad1a58b2a821218239249a9e4365eaff6649d31180c1669"},
+    {file = "coverage-5.5-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:900fbf7759501bc7807fd6638c947d7a831fc9fdf742dc10f02956ff7220fa90"},
+    {file = "coverage-5.5-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:004d1880bed2d97151facef49f08e255a20ceb6f9432df75f4eef018fdd5a78c"},
+    {file = "coverage-5.5-cp27-cp27m-win32.whl", hash = "sha256:06191eb60f8d8a5bc046f3799f8a07a2d7aefb9504b0209aff0b47298333302a"},
+    {file = "coverage-5.5-cp27-cp27m-win_amd64.whl", hash = "sha256:7501140f755b725495941b43347ba8a2777407fc7f250d4f5a7d2a1050ba8e82"},
+    {file = "coverage-5.5-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:372da284cfd642d8e08ef606917846fa2ee350f64994bebfbd3afb0040436905"},
+    {file = "coverage-5.5-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:8963a499849a1fc54b35b1c9f162f4108017b2e6db2c46c1bed93a72262ed083"},
+    {file = "coverage-5.5-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:869a64f53488f40fa5b5b9dcb9e9b2962a66a87dab37790f3fcfb5144b996ef5"},
+    {file = "coverage-5.5-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:4a7697d8cb0f27399b0e393c0b90f0f1e40c82023ea4d45d22bce7032a5d7b81"},
+    {file = "coverage-5.5-cp310-cp310-macosx_10_14_x86_64.whl", hash = "sha256:8d0a0725ad7c1a0bcd8d1b437e191107d457e2ec1084b9f190630a4fb1af78e6"},
+    {file = "coverage-5.5-cp310-cp310-manylinux1_x86_64.whl", hash = "sha256:51cb9476a3987c8967ebab3f0fe144819781fca264f57f89760037a2ea191cb0"},
+    {file = "coverage-5.5-cp310-cp310-win_amd64.whl", hash = "sha256:c0891a6a97b09c1f3e073a890514d5012eb256845c451bd48f7968ef939bf4ae"},
+    {file = "coverage-5.5-cp35-cp35m-macosx_10_9_x86_64.whl", hash = "sha256:3487286bc29a5aa4b93a072e9592f22254291ce96a9fbc5251f566b6b7343cdb"},
+    {file = "coverage-5.5-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:deee1077aae10d8fa88cb02c845cfba9b62c55e1183f52f6ae6a2df6a2187160"},
+    {file = "coverage-5.5-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:f11642dddbb0253cc8853254301b51390ba0081750a8ac03f20ea8103f0c56b6"},
+    {file = "coverage-5.5-cp35-cp35m-manylinux2010_i686.whl", hash = "sha256:6c90e11318f0d3c436a42409f2749ee1a115cd8b067d7f14c148f1ce5574d701"},
+    {file = "coverage-5.5-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:30c77c1dc9f253283e34c27935fded5015f7d1abe83bc7821680ac444eaf7793"},
+    {file = "coverage-5.5-cp35-cp35m-win32.whl", hash = "sha256:9a1ef3b66e38ef8618ce5fdc7bea3d9f45f3624e2a66295eea5e57966c85909e"},
+    {file = "coverage-5.5-cp35-cp35m-win_amd64.whl", hash = "sha256:972c85d205b51e30e59525694670de6a8a89691186012535f9d7dbaa230e42c3"},
+    {file = "coverage-5.5-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:af0e781009aaf59e25c5a678122391cb0f345ac0ec272c7961dc5455e1c40066"},
+    {file = "coverage-5.5-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:74d881fc777ebb11c63736622b60cb9e4aee5cace591ce274fb69e582a12a61a"},
+    {file = "coverage-5.5-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:92b017ce34b68a7d67bd6d117e6d443a9bf63a2ecf8567bb3d8c6c7bc5014465"},
+    {file = "coverage-5.5-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:d636598c8305e1f90b439dbf4f66437de4a5e3c31fdf47ad29542478c8508bbb"},
+    {file = "coverage-5.5-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:41179b8a845742d1eb60449bdb2992196e211341818565abded11cfa90efb821"},
+    {file = "coverage-5.5-cp36-cp36m-win32.whl", hash = "sha256:040af6c32813fa3eae5305d53f18875bedd079960822ef8ec067a66dd8afcd45"},
+    {file = "coverage-5.5-cp36-cp36m-win_amd64.whl", hash = "sha256:5fec2d43a2cc6965edc0bb9e83e1e4b557f76f843a77a2496cbe719583ce8184"},
+    {file = "coverage-5.5-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:18ba8bbede96a2c3dde7b868de9dcbd55670690af0988713f0603f037848418a"},
+    {file = "coverage-5.5-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:2910f4d36a6a9b4214bb7038d537f015346f413a975d57ca6b43bf23d6563b53"},
+    {file = "coverage-5.5-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:f0b278ce10936db1a37e6954e15a3730bea96a0997c26d7fee88e6c396c2086d"},
+    {file = "coverage-5.5-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:796c9c3c79747146ebd278dbe1e5c5c05dd6b10cc3bcb8389dfdf844f3ead638"},
+    {file = "coverage-5.5-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:53194af30d5bad77fcba80e23a1441c71abfb3e01192034f8246e0d8f99528f3"},
+    {file = "coverage-5.5-cp37-cp37m-win32.whl", hash = "sha256:184a47bbe0aa6400ed2d41d8e9ed868b8205046518c52464fde713ea06e3a74a"},
+    {file = "coverage-5.5-cp37-cp37m-win_amd64.whl", hash = "sha256:2949cad1c5208b8298d5686d5a85b66aae46d73eec2c3e08c817dd3513e5848a"},
+    {file = "coverage-5.5-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:217658ec7187497e3f3ebd901afdca1af062b42cfe3e0dafea4cced3983739f6"},
+    {file = "coverage-5.5-cp38-cp38-manylinux1_i686.whl", hash = "sha256:1aa846f56c3d49205c952d8318e76ccc2ae23303351d9270ab220004c580cfe2"},
+    {file = "coverage-5.5-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:24d4a7de75446be83244eabbff746d66b9240ae020ced65d060815fac3423759"},
+    {file = "coverage-5.5-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:d1f8bf7b90ba55699b3a5e44930e93ff0189aa27186e96071fac7dd0d06a1873"},
+    {file = "coverage-5.5-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:970284a88b99673ccb2e4e334cfb38a10aab7cd44f7457564d11898a74b62d0a"},
+    {file = "coverage-5.5-cp38-cp38-win32.whl", hash = "sha256:01d84219b5cdbfc8122223b39a954820929497a1cb1422824bb86b07b74594b6"},
+    {file = "coverage-5.5-cp38-cp38-win_amd64.whl", hash = "sha256:2e0d881ad471768bf6e6c2bf905d183543f10098e3b3640fc029509530091502"},
+    {file = "coverage-5.5-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:d1f9ce122f83b2305592c11d64f181b87153fc2c2bbd3bb4a3dde8303cfb1a6b"},
+    {file = "coverage-5.5-cp39-cp39-manylinux1_i686.whl", hash = "sha256:13c4ee887eca0f4c5a247b75398d4114c37882658300e153113dafb1d76de529"},
+    {file = "coverage-5.5-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:52596d3d0e8bdf3af43db3e9ba8dcdaac724ba7b5ca3f6358529d56f7a166f8b"},
+    {file = "coverage-5.5-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:2cafbbb3af0733db200c9b5f798d18953b1a304d3f86a938367de1567f4b5bff"},
+    {file = "coverage-5.5-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:44d654437b8ddd9eee7d1eaee28b7219bec228520ff809af170488fd2fed3e2b"},
+    {file = "coverage-5.5-cp39-cp39-win32.whl", hash = "sha256:d314ed732c25d29775e84a960c3c60808b682c08d86602ec2c3008e1202e3bb6"},
+    {file = "coverage-5.5-cp39-cp39-win_amd64.whl", hash = "sha256:13034c4409db851670bc9acd836243aeee299949bd5673e11844befcb0149f03"},
+    {file = "coverage-5.5-pp36-none-any.whl", hash = "sha256:f030f8873312a16414c0d8e1a1ddff2d3235655a2174e3648b4fa66b3f2f1079"},
+    {file = "coverage-5.5-pp37-none-any.whl", hash = "sha256:2a3859cb82dcbda1cfd3e6f71c27081d18aa251d20a17d87d26d4cd216fb0af4"},
+    {file = "coverage-5.5.tar.gz", hash = "sha256:ebe78fe9a0e874362175b02371bdfbee64d8edc42a044253ddf4ee7d3c15212c"},
 ]
 dataclasses = [
     {file = "dataclasses-0.8-py3-none-any.whl", hash = "sha256:0201d89fa866f68c8ebd9d08ee6ff50c0b255f8ec63a71c16fda7af82bb887bf"},
@@ -658,8 +662,8 @@ flake8 = [
     {file = "flake8-3.8.4.tar.gz", hash = "sha256:aadae8761ec651813c24be05c6f7b4680857ef6afaae4651a4eccaef97ce6c3b"},
 ]
 flake8-bugbear = [
-    {file = "flake8-bugbear-20.11.1.tar.gz", hash = "sha256:528020129fea2dea33a466b9d64ab650aa3e5f9ffc788b70ea4bc6cf18283538"},
-    {file = "flake8_bugbear-20.11.1-py36.py37.py38-none-any.whl", hash = "sha256:f35b8135ece7a014bc0aee5b5d485334ac30a6da48494998cc1fabf7ec70d703"},
+    {file = "flake8-bugbear-21.3.1.tar.gz", hash = "sha256:ea08deb8922486e856b38c9338936de1e1de4ad9e7c912be142673d5afe5ac89"},
+    {file = "flake8_bugbear-21.3.1-py36.py37.py38-none-any.whl", hash = "sha256:0c5b949dc1f33d2adae284294d39a81dd11534fbf689890fb22ee532cab959d9"},
 ]
 flake8-docstrings = [
     {file = "flake8-docstrings-1.5.0.tar.gz", hash = "sha256:3d5a31c7ec6b7367ea6506a87ec293b94a0a46c0bce2bb4975b7f1d09b6f3717"},
@@ -686,16 +690,16 @@ flake8-tidy-imports = [
     {file = "flake8_tidy_imports-4.2.1-py3-none-any.whl", hash = "sha256:76e36fbbfdc8e3c5017f9a216c2855a298be85bc0631e66777f4e6a07a859dc4"},
 ]
 identify = [
-    {file = "identify-1.5.11-py2.py3-none-any.whl", hash = "sha256:7aef7a5104d6254c162990e54a203cdc0fd202046b6c415bd5d636472f6565c4"},
-    {file = "identify-1.5.11.tar.gz", hash = "sha256:b2c71bf9f5c482c389cef816f3a15f1c9d7429ad70f497d4a2e522442d80c6de"},
+    {file = "identify-2.1.0-py2.py3-none-any.whl", hash = "sha256:2a5fdf2f5319cc357eda2550bea713a404392495961022cf2462624ce62f0f46"},
+    {file = "identify-2.1.0.tar.gz", hash = "sha256:2179e7359471ab55729f201b3fdf7dc2778e221f868410fedcb0987b791ba552"},
 ]
 importlib-metadata = [
-    {file = "importlib_metadata-2.1.1-py2.py3-none-any.whl", hash = "sha256:c2d6341ff566f609e89a2acb2db190e5e1d23d5409d6cc8d2fe34d72443876d4"},
-    {file = "importlib_metadata-2.1.1.tar.gz", hash = "sha256:b8de9eff2b35fb037368f28a7df1df4e6436f578fa74423505b6c6a778d5b5dd"},
+    {file = "importlib_metadata-3.7.0-py3-none-any.whl", hash = "sha256:c6af5dbf1126cd959c4a8d8efd61d4d3c83bddb0459a17e554284a077574b614"},
+    {file = "importlib_metadata-3.7.0.tar.gz", hash = "sha256:24499ffde1b80be08284100393955842be4a59c7c16bbf2738aad0e464a8e0aa"},
 ]
 importlib-resources = [
-    {file = "importlib_resources-4.1.1-py3-none-any.whl", hash = "sha256:0a948d0c8c3f9344de62997e3f73444dbba233b1eaf24352933c2d264b9e4182"},
-    {file = "importlib_resources-4.1.1.tar.gz", hash = "sha256:6b45007a479c4ec21165ae3ffbe37faf35404e2041fac6ae1da684f38530ca73"},
+    {file = "importlib_resources-5.1.2-py3-none-any.whl", hash = "sha256:ebab3efe74d83b04d6bf5cd9a17f0c5c93e60fb60f30c90f56265fce4682a469"},
+    {file = "importlib_resources-5.1.2.tar.gz", hash = "sha256:642586fc4740bd1cad7690f836b3321309402b20b332529f25617ff18e8e1370"},
 ]
 iniconfig = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
@@ -717,8 +721,8 @@ nodeenv = [
     {file = "nodeenv-1.5.0.tar.gz", hash = "sha256:ab45090ae383b716c4ef89e690c41ff8c2b257b85b309f01f3654df3d084bd7c"},
 ]
 packaging = [
-    {file = "packaging-20.8-py2.py3-none-any.whl", hash = "sha256:24e0da08660a87484d1602c30bb4902d74816b6985b93de36926f5bc95741858"},
-    {file = "packaging-20.8.tar.gz", hash = "sha256:78598185a7008a470d64526a8059de9aaa449238f280fc9eb6b13ba6c4109093"},
+    {file = "packaging-20.9-py2.py3-none-any.whl", hash = "sha256:67714da7f7bc052e064859c05c595155bd1ee9f69f76557e21f051443c20947a"},
+    {file = "packaging-20.9.tar.gz", hash = "sha256:5b327ac1320dc863dca72f4514ecc086f31186744b84a230374cc1fd776feae5"},
 ]
 pathspec = [
     {file = "pathspec-0.8.1-py2.py3-none-any.whl", hash = "sha256:aa0cb481c4041bf52ffa7b0d8fa6cd3e88a2ca4879c533c9153882ee2556790d"},
@@ -733,8 +737,8 @@ pluggy = [
     {file = "pluggy-0.13.1.tar.gz", hash = "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0"},
 ]
 pre-commit = [
-    {file = "pre_commit-2.9.3-py2.py3-none-any.whl", hash = "sha256:6c86d977d00ddc8a60d68eec19f51ef212d9462937acf3ea37c7adec32284ac0"},
-    {file = "pre_commit-2.9.3.tar.gz", hash = "sha256:ee784c11953e6d8badb97d19bc46b997a3a9eded849881ec587accd8608d74a4"},
+    {file = "pre_commit-2.10.1-py2.py3-none-any.whl", hash = "sha256:16212d1fde2bed88159287da88ff03796863854b04dc9f838a55979325a3d20e"},
+    {file = "pre_commit-2.10.1.tar.gz", hash = "sha256:399baf78f13f4de82a29b649afd74bef2c4e28eb4f021661fc7f29246e8c7a3a"},
 ]
 py = [
     {file = "py-1.10.0-py2.py3-none-any.whl", hash = "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"},
@@ -757,29 +761,39 @@ pyparsing = [
     {file = "pyparsing-2.4.7.tar.gz", hash = "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1"},
 ]
 pytest = [
-    {file = "pytest-6.2.1-py3-none-any.whl", hash = "sha256:1969f797a1a0dbd8ccf0fecc80262312729afea9c17f1d70ebf85c5e76c6f7c8"},
-    {file = "pytest-6.2.1.tar.gz", hash = "sha256:66e419b1899bc27346cb2c993e12c5e5e8daba9073c1fbce33b9807abc95c306"},
+    {file = "pytest-6.2.2-py3-none-any.whl", hash = "sha256:b574b57423e818210672e07ca1fa90aaf194a4f63f3ab909a2c67ebb22913839"},
+    {file = "pytest-6.2.2.tar.gz", hash = "sha256:9d1edf9e7d0b84d72ea3dbcdfd22b35fb543a5e8f2a60092dd578936bf63d7f9"},
 ]
 pytest-check = [
     {file = "pytest_check-1.0.1-py2.py3-none-any.whl", hash = "sha256:037d1a0777c7ebbe7b4e17d09ca7956793aa86d36bea851c0edeed361d0928bc"},
     {file = "pytest_check-1.0.1.tar.gz", hash = "sha256:da5849adf5e51bd0c1f7204655b3594a68463353ec8da06c082c1ab0548901c4"},
 ]
 pytest-cov = [
-    {file = "pytest-cov-2.10.1.tar.gz", hash = "sha256:47bd0ce14056fdd79f93e1713f88fad7bdcc583dcd7783da86ef2f085a0bb88e"},
-    {file = "pytest_cov-2.10.1-py2.py3-none-any.whl", hash = "sha256:45ec2d5182f89a81fc3eb29e3d1ed3113b9e9a873bcddb2a71faaab066110191"},
+    {file = "pytest-cov-2.11.1.tar.gz", hash = "sha256:359952d9d39b9f822d9d29324483e7ba04a3a17dd7d05aa6beb7ea01e359e5f7"},
+    {file = "pytest_cov-2.11.1-py2.py3-none-any.whl", hash = "sha256:bdb9fdb0b85a7cc825269a4c56b48ccaa5c7e365054b6038772c32ddcdc969da"},
 ]
 pyyaml = [
-    {file = "PyYAML-5.3.1-cp27-cp27m-win32.whl", hash = "sha256:74809a57b329d6cc0fdccee6318f44b9b8649961fa73144a98735b0aaf029f1f"},
-    {file = "PyYAML-5.3.1-cp27-cp27m-win_amd64.whl", hash = "sha256:240097ff019d7c70a4922b6869d8a86407758333f02203e0fc6ff79c5dcede76"},
-    {file = "PyYAML-5.3.1-cp35-cp35m-win32.whl", hash = "sha256:4f4b913ca1a7319b33cfb1369e91e50354d6f07a135f3b901aca02aa95940bd2"},
-    {file = "PyYAML-5.3.1-cp35-cp35m-win_amd64.whl", hash = "sha256:cc8955cfbfc7a115fa81d85284ee61147059a753344bc51098f3ccd69b0d7e0c"},
-    {file = "PyYAML-5.3.1-cp36-cp36m-win32.whl", hash = "sha256:7739fc0fa8205b3ee8808aea45e968bc90082c10aef6ea95e855e10abf4a37b2"},
-    {file = "PyYAML-5.3.1-cp36-cp36m-win_amd64.whl", hash = "sha256:69f00dca373f240f842b2931fb2c7e14ddbacd1397d57157a9b005a6a9942648"},
-    {file = "PyYAML-5.3.1-cp37-cp37m-win32.whl", hash = "sha256:d13155f591e6fcc1ec3b30685d50bf0711574e2c0dfffd7644babf8b5102ca1a"},
-    {file = "PyYAML-5.3.1-cp37-cp37m-win_amd64.whl", hash = "sha256:73f099454b799e05e5ab51423c7bcf361c58d3206fa7b0d555426b1f4d9a3eaf"},
-    {file = "PyYAML-5.3.1-cp38-cp38-win32.whl", hash = "sha256:06a0d7ba600ce0b2d2fe2e78453a470b5a6e000a985dd4a4e54e436cc36b0e97"},
-    {file = "PyYAML-5.3.1-cp38-cp38-win_amd64.whl", hash = "sha256:95f71d2af0ff4227885f7a6605c37fd53d3a106fcab511b8860ecca9fcf400ee"},
-    {file = "PyYAML-5.3.1.tar.gz", hash = "sha256:b8eac752c5e14d3eca0e6dd9199cd627518cb5ec06add0de9d32baeee6fe645d"},
+    {file = "PyYAML-5.4.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:3b2b1824fe7112845700f815ff6a489360226a5609b96ec2190a45e62a9fc922"},
+    {file = "PyYAML-5.4.1-cp27-cp27m-win32.whl", hash = "sha256:129def1b7c1bf22faffd67b8f3724645203b79d8f4cc81f674654d9902cb4393"},
+    {file = "PyYAML-5.4.1-cp27-cp27m-win_amd64.whl", hash = "sha256:4465124ef1b18d9ace298060f4eccc64b0850899ac4ac53294547536533800c8"},
+    {file = "PyYAML-5.4.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:bb4191dfc9306777bc594117aee052446b3fa88737cd13b7188d0e7aa8162185"},
+    {file = "PyYAML-5.4.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:6c78645d400265a062508ae399b60b8c167bf003db364ecb26dcab2bda048253"},
+    {file = "PyYAML-5.4.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:4e0583d24c881e14342eaf4ec5fbc97f934b999a6828693a99157fde912540cc"},
+    {file = "PyYAML-5.4.1-cp36-cp36m-win32.whl", hash = "sha256:3bd0e463264cf257d1ffd2e40223b197271046d09dadf73a0fe82b9c1fc385a5"},
+    {file = "PyYAML-5.4.1-cp36-cp36m-win_amd64.whl", hash = "sha256:e4fac90784481d221a8e4b1162afa7c47ed953be40d31ab4629ae917510051df"},
+    {file = "PyYAML-5.4.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:5accb17103e43963b80e6f837831f38d314a0495500067cb25afab2e8d7a4018"},
+    {file = "PyYAML-5.4.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:e1d4970ea66be07ae37a3c2e48b5ec63f7ba6804bdddfdbd3cfd954d25a82e63"},
+    {file = "PyYAML-5.4.1-cp37-cp37m-win32.whl", hash = "sha256:dd5de0646207f053eb0d6c74ae45ba98c3395a571a2891858e87df7c9b9bd51b"},
+    {file = "PyYAML-5.4.1-cp37-cp37m-win_amd64.whl", hash = "sha256:08682f6b72c722394747bddaf0aa62277e02557c0fd1c42cb853016a38f8dedf"},
+    {file = "PyYAML-5.4.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:d2d9808ea7b4af864f35ea216be506ecec180628aced0704e34aca0b040ffe46"},
+    {file = "PyYAML-5.4.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:8c1be557ee92a20f184922c7b6424e8ab6691788e6d86137c5d93c1a6ec1b8fb"},
+    {file = "PyYAML-5.4.1-cp38-cp38-win32.whl", hash = "sha256:fa5ae20527d8e831e8230cbffd9f8fe952815b2b7dae6ffec25318803a7528fc"},
+    {file = "PyYAML-5.4.1-cp38-cp38-win_amd64.whl", hash = "sha256:0f5f5786c0e09baddcd8b4b45f20a7b5d61a7e7e99846e3c799b05c7c53fa696"},
+    {file = "PyYAML-5.4.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:294db365efa064d00b8d1ef65d8ea2c3426ac366c0c4368d930bf1c5fb497f77"},
+    {file = "PyYAML-5.4.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:74c1485f7707cf707a7aef42ef6322b8f97921bd89be2ab6317fd782c2d53183"},
+    {file = "PyYAML-5.4.1-cp39-cp39-win32.whl", hash = "sha256:49d4cdd9065b9b6e206d0595fee27a96b5dd22618e7520c33204a4a3239d5b10"},
+    {file = "PyYAML-5.4.1-cp39-cp39-win_amd64.whl", hash = "sha256:c20cfa2d49991c8b4147af39859b167664f2ad4561704ee74c1de03318e898db"},
+    {file = "PyYAML-5.4.1.tar.gz", hash = "sha256:607774cbba28732bfa802b54baa7484215f530991055bb562efbed5b2f20a45e"},
 ]
 regex = [
     {file = "regex-2020.11.13-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:8b882a78c320478b12ff024e81dc7d43c1462aa4a3341c754ee65d857a521f85"},
@@ -829,16 +843,16 @@ six = [
     {file = "six-1.15.0.tar.gz", hash = "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259"},
 ]
 snowballstemmer = [
-    {file = "snowballstemmer-2.0.0-py2.py3-none-any.whl", hash = "sha256:209f257d7533fdb3cb73bdbd24f436239ca3b2fa67d56f6ff88e86be08cc5ef0"},
-    {file = "snowballstemmer-2.0.0.tar.gz", hash = "sha256:df3bac3df4c2c01363f3dd2cfa78cce2840a79b9f1c2d2de9ce8d31683992f52"},
+    {file = "snowballstemmer-2.1.0-py2.py3-none-any.whl", hash = "sha256:b51b447bea85f9968c13b650126a888aabd4cb4463fca868ec596826325dedc2"},
+    {file = "snowballstemmer-2.1.0.tar.gz", hash = "sha256:e997baa4f2e9139951b6f4c631bad912dfd3c792467e2f03d7239464af90e914"},
 ]
 toml = [
     {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
     {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
 ]
 tox = [
-    {file = "tox-3.20.1-py2.py3-none-any.whl", hash = "sha256:42ce19ce5dc2f6d6b1fdc5666c476e1f1e2897359b47e0aa3a5b774f335d57c2"},
-    {file = "tox-3.20.1.tar.gz", hash = "sha256:4321052bfe28f9d85082341ca8e233e3ea901fdd14dab8a5d3fbd810269fbaf6"},
+    {file = "tox-3.23.0-py2.py3-none-any.whl", hash = "sha256:e007673f3595cede9b17a7c4962389e4305d4a3682a6c5a4159a1453b4f326aa"},
+    {file = "tox-3.23.0.tar.gz", hash = "sha256:05a4dbd5e4d3d8269b72b55600f0b0303e2eb47ad5c6fe76d3576f4c58d93661"},
 ]
 typed-ast = [
     {file = "typed_ast-1.4.2-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:7703620125e4fb79b64aa52427ec192822e9f45d37d4b6625ab37ef403e1df70"},
@@ -878,10 +892,10 @@ typing-extensions = [
     {file = "typing_extensions-3.7.4.3.tar.gz", hash = "sha256:99d4073b617d30288f569d3f13d2bd7548c3a7e4c8de87db09a9d29bb3a4a60c"},
 ]
 virtualenv = [
-    {file = "virtualenv-20.2.2-py2.py3-none-any.whl", hash = "sha256:54b05fc737ea9c9ee9f8340f579e5da5b09fb64fd010ab5757eb90268616907c"},
-    {file = "virtualenv-20.2.2.tar.gz", hash = "sha256:b7a8ec323ee02fb2312f098b6b4c9de99559b462775bc8fe3627a73706603c1b"},
+    {file = "virtualenv-20.4.2-py2.py3-none-any.whl", hash = "sha256:2be72df684b74df0ea47679a7df93fd0e04e72520022c57b479d8f881485dbe3"},
+    {file = "virtualenv-20.4.2.tar.gz", hash = "sha256:147b43894e51dd6bba882cf9c282447f780e2251cd35172403745fc381a0a80d"},
 ]
 zipp = [
-    {file = "zipp-3.4.0-py3-none-any.whl", hash = "sha256:102c24ef8f171fd729d46599845e95c7ab894a4cf45f5de11a44cc7444fb1108"},
-    {file = "zipp-3.4.0.tar.gz", hash = "sha256:ed5eee1974372595f9e416cc7bbeeb12335201d8081ca8a0743c954d4446e5cb"},
+    {file = "zipp-3.4.1-py3-none-any.whl", hash = "sha256:51cb66cc54621609dd593d1787f286ee42a5c0adbb4b29abea5a63edc3e03098"},
+    {file = "zipp-3.4.1.tar.gz", hash = "sha256:3607921face881ba3e026887d8150cca609d517579abe052ac81fc5aeffdbd76"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
+    "Development Status :: 5 - Production/Stable",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.6",
@@ -22,6 +23,7 @@ classifiers = [
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Software Development :: Quality Assurance",
+    "Typing :: Typed",
 ]
 include = ["CHANGELOG.md"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flake8-annotations"
-version = "2.5.0"
+version = "2.6.0"
 description = "Flake8 Type Annotation Checks"
 license = "MIT"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ typed-ast = {version="^1.4,<2.0", python="<3.8"}
 
 [tool.poetry.dev-dependencies]
 black = {version = "^20.8b1"}
-flake8-bugbear = "^20.1"
+flake8-bugbear = "^21.3"
 flake8-docstrings = "^1.5"
 flake8-fixme = "^1.1"
 flake8-formatter-junit-xml = "^0.0"

--- a/testing/helpers.py
+++ b/testing/helpers.py
@@ -1,7 +1,11 @@
-from typing import Generator, Iterable, List, Optional, Sequence, Tuple
+import typing as t
 
 from flake8_annotations import Function, FunctionVisitor, PY_GTE_38
-from flake8_annotations.checker import TypeHintChecker
+from flake8_annotations.checker import (
+    TypeHintChecker,
+    _DEFAULT_DISPATCH_DECORATORS,
+    _DEFAULT_OVERLOAD_DECORATORS,
+)
 from flake8_annotations.error_codes import Error
 from pytest_check import check_func
 
@@ -11,7 +15,7 @@ else:
     from typed_ast import ast3 as ast
 
 
-def parse_source(src: str) -> Tuple[ast.Module, List[str]]:
+def parse_source(src: str) -> t.Tuple[ast.Module, t.List[str]]:
     """Parse the provided Python source string and return an (typed AST, source) tuple."""
     if PY_GTE_38:
         # Built-in ast requires a flag to parse type comments
@@ -32,7 +36,9 @@ def check_source(
     allow_untyped_defs: bool = False,
     allow_untyped_nested: bool = False,
     mypy_init_return: bool = False,
-) -> Generator[Error, None, None]:
+    dispatch_decorators: t.AbstractSet[str] = frozenset(_DEFAULT_DISPATCH_DECORATORS),
+    overload_decorators: t.AbstractSet[str] = frozenset(_DEFAULT_OVERLOAD_DECORATORS),
+) -> t.Generator[Error, None, None]:
     """Helper for generating linting errors from the provided source code."""
     _, lines = parse_source(src)
     checker_instance = TypeHintChecker(None, lines)
@@ -43,11 +49,13 @@ def check_source(
     checker_instance.allow_untyped_defs = allow_untyped_defs
     checker_instance.allow_untyped_nested = allow_untyped_nested
     checker_instance.mypy_init_return = mypy_init_return
+    checker_instance.dispatch_decorators = dispatch_decorators
+    checker_instance.overload_decorators = overload_decorators
 
     return checker_instance.run()
 
 
-def functions_from_source(src: str) -> List[Function]:
+def functions_from_source(src: str) -> t.List[Function]:
     """Helper for obtaining a list of Function objects from the provided source code."""
     tree, lines = parse_source(src)
     visitor = FunctionVisitor(lines)
@@ -56,7 +64,9 @@ def functions_from_source(src: str) -> List[Function]:
     return visitor.function_definitions
 
 
-def find_matching_function(func_list: Iterable[Function], match_name: str) -> Optional[Function]:
+def find_matching_function(
+    func_list: t.Iterable[Function], match_name: str
+) -> t.Optional[Function]:
     """
     Iterate over a list of Function objects & find the first matching named function.
 
@@ -67,12 +77,12 @@ def find_matching_function(func_list: Iterable[Function], match_name: str) -> Op
 
 
 @check_func
-def check_is_empty(in_sequence: Sequence, msg: str = "") -> None:
+def check_is_empty(in_sequence: t.Sequence, msg: str = "") -> None:
     """Check whether the input sequence is empty."""
     assert not in_sequence
 
 
 @check_func
-def check_is_not_empty(in_sequence: Sequence, msg: str = "") -> None:
+def check_is_not_empty(in_sequence: t.Sequence, msg: str = "") -> None:
     """Check whether the input sequence is not empty."""
     assert in_sequence

--- a/testing/helpers.py
+++ b/testing/helpers.py
@@ -2,11 +2,11 @@ import typing as t
 
 from flake8_annotations import Function, FunctionVisitor, PY_GTE_38
 from flake8_annotations.checker import (
+    FORMATTED_ERROR,
     TypeHintChecker,
     _DEFAULT_DISPATCH_DECORATORS,
     _DEFAULT_OVERLOAD_DECORATORS,
 )
-from flake8_annotations.error_codes import Error
 from pytest_check import check_func
 
 if PY_GTE_38:
@@ -38,7 +38,7 @@ def check_source(
     mypy_init_return: bool = False,
     dispatch_decorators: t.AbstractSet[str] = frozenset(_DEFAULT_DISPATCH_DECORATORS),
     overload_decorators: t.AbstractSet[str] = frozenset(_DEFAULT_OVERLOAD_DECORATORS),
-) -> t.Generator[Error, None, None]:
+) -> t.Generator[FORMATTED_ERROR, None, None]:
     """Helper for generating linting errors from the provided source code."""
     _, lines = parse_source(src)
     checker_instance = TypeHintChecker(None, lines)
@@ -64,9 +64,7 @@ def functions_from_source(src: str) -> t.List[Function]:
     return visitor.function_definitions
 
 
-def find_matching_function(
-    func_list: t.Iterable[Function], match_name: str
-) -> t.Optional[Function]:
+def find_matching_function(func_list: t.Iterable[Function], match_name: str) -> Function:
     """
     Iterate over a list of Function objects & find the first matching named function.
 

--- a/testing/test_cases/argument_parsing_test_cases.py
+++ b/testing/test_cases/argument_parsing_test_cases.py
@@ -15,7 +15,7 @@ class ArgumentTestCase(NamedTuple):
     """
 
     src: str
-    args: Tuple[Argument]
+    args: Tuple[Argument, ...]
     py38_only: bool = False
 
 

--- a/testing/test_cases/classifier_object_attributes.py
+++ b/testing/test_cases/classifier_object_attributes.py
@@ -1,4 +1,4 @@
-from typing import NamedTuple
+from typing import NamedTuple, Optional
 
 from flake8_annotations import error_codes
 from flake8_annotations.enums import AnnotationType, ClassDecoratorType, FunctionType
@@ -11,7 +11,7 @@ class RT(NamedTuple):
 
     function_type: FunctionType
     is_class_method: bool
-    class_decorator_type: ClassDecoratorType
+    class_decorator_type: Optional[ClassDecoratorType]
 
 
 return_classifications = {
@@ -48,7 +48,7 @@ class AT(NamedTuple):
 
     is_class_method: bool
     is_first_arg: bool
-    class_decorator_type: ClassDecoratorType
+    class_decorator_type: Optional[ClassDecoratorType]
     annotation_type: AnnotationType
 
 

--- a/testing/test_cases/column_line_numbers_test_cases.py
+++ b/testing/test_cases/column_line_numbers_test_cases.py
@@ -139,13 +139,25 @@ parser_test_cases = {
         ),
         error_locations=((1, 10),),
     ),
-    "multiline_docstring_only_summary": ParserTestCase(
+    "multiline_docstring_summary_at_open": ParserTestCase(
         src=dedent(
             """\
             def foo():                 # 1
                 \"\"\"Some docstring.  # 2
                 \"\"\"                 # 3
                 ...                    # 4
+            """
+        ),
+        error_locations=((1, 10),),
+    ),
+    "multiline_docstring_single_line_summary": ParserTestCase(
+        src=dedent(
+            """\
+            def foo():           # 1
+                \"\"\"           # 2
+                Some docstring.  # 3
+                \"\"\"           # 4
+                ...              # 5
             """
         ),
         error_locations=((1, 10),),

--- a/testing/test_cases/column_line_numbers_test_cases.py
+++ b/testing/test_cases/column_line_numbers_test_cases.py
@@ -12,7 +12,7 @@ class ParserTestCase(NamedTuple):
     """
 
     src: str
-    error_locations: Tuple[Tuple[int, int]]
+    error_locations: Tuple[Tuple[int, int], ...]
 
 
 parser_test_cases = {

--- a/testing/test_cases/column_line_numbers_test_cases.py
+++ b/testing/test_cases/column_line_numbers_test_cases.py
@@ -57,7 +57,7 @@ parser_test_cases = {
         ),
         error_locations=((1, 10),),
     ),
-    "multi_line_docstring": ParserTestCase(
+    "multiline_docstring": ParserTestCase(
         src=dedent(
             """\
             def snek():              # 1
@@ -90,7 +90,7 @@ parser_test_cases = {
         ),
         error_locations=((1, 10),),
     ),
-    "multi_line_docstring_with_colon": ParserTestCase(
+    "multiline_docstring_with_colon": ParserTestCase(
         src=dedent(
             """\
             def snek():               # 1
@@ -127,5 +127,27 @@ parser_test_cases = {
             """
         ),
         error_locations=((1, 16),),
+    ),
+    "multiline_docstring_no_content": ParserTestCase(
+        src=dedent(
+            """\
+            def foo():  # 1
+                \"\"\"  # 2
+                \"\"\"  # 3
+                ...     # 4
+            """
+        ),
+        error_locations=((1, 10),),
+    ),
+    "multiline_docstring_only_summary": ParserTestCase(
+        src=dedent(
+            """\
+            def foo():                 # 1
+                \"\"\"Some docstring.  # 2
+                \"\"\"                 # 3
+                ...                    # 4
+            """
+        ),
+        error_locations=((1, 10),),
     ),
 }

--- a/testing/test_cases/dispatch_decorator_test_cases.py
+++ b/testing/test_cases/dispatch_decorator_test_cases.py
@@ -19,11 +19,6 @@ dispatch_decorator_test_cases = {
             @functools.singledispatch
             def foo(a):
                 print(a)
-
-            @foo.register
-            def _(a: list) -> None:
-                for idx, thing in enumerate(a):
-                    print(idx, thing)
             """
         ),
         should_yield_error=False,
@@ -34,11 +29,6 @@ dispatch_decorator_test_cases = {
             @fnctls.singledispatch
             def foo(a):
                 print(a)
-
-            @foo.register
-            def _(a: list) -> None:
-                for idx, thing in enumerate(a):
-                    print(idx, thing)
             """
         ),
         should_yield_error=False,
@@ -49,11 +39,6 @@ dispatch_decorator_test_cases = {
             @singledispatch
             def foo(a):
                 print(a)
-
-            @foo.register
-            def _(a: list) -> None:
-                for idx, thing in enumerate(a):
-                    print(idx, thing)
             """
         ),
         should_yield_error=False,
@@ -64,11 +49,6 @@ dispatch_decorator_test_cases = {
             @sngldsptch
             def foo(a):
                 print(a)
-
-            @foo.register
-            def _(a: list) -> None:
-                for idx, thing in enumerate(a):
-                    print(idx, thing)
             """
         ),
         should_yield_error=True,
@@ -79,11 +59,6 @@ dispatch_decorator_test_cases = {
             @sngldsptch
             def foo(a):
                 print(a)
-
-            @foo.register
-            def _(a: list) -> None:
-                for idx, thing in enumerate(a):
-                    print(idx, thing)
             """
         ),
         should_yield_error=False,
@@ -96,11 +71,6 @@ dispatch_decorator_test_cases = {
                 @functools.singledispatchmethod
                 def foo(self, a):
                     print(a)
-
-                @foo.register
-                def _(self: "Foo", a: list) -> None:
-                    for idx, thing in enumerate(a):
-                        print(idx, thing)
             """
         ),
         should_yield_error=False,
@@ -112,11 +82,6 @@ dispatch_decorator_test_cases = {
                 @fnctls.singledispatchmethod
                 def foo(self, a):
                     print(a)
-
-                @foo.register
-                def _(self: "Foo", a: list) -> None:
-                    for idx, thing in enumerate(a):
-                        print(idx, thing)
             """
         ),
         should_yield_error=False,
@@ -128,11 +93,6 @@ dispatch_decorator_test_cases = {
                 @singledispatchmethod
                 def foo(self, a):
                     print(a)
-
-                @foo.register
-                def _(self: "Foo", a: list) -> None:
-                    for idx, thing in enumerate(a):
-                        print(idx, thing)
             """
         ),
         should_yield_error=False,
@@ -144,11 +104,6 @@ dispatch_decorator_test_cases = {
                 @sngldsptchmthd
                 def foo(self, a):
                     print(a)
-
-                @foo.register
-                def _(self: "Foo", a: list) -> None:
-                    for idx, thing in enumerate(a):
-                        print(idx, thing)
             """
         ),
         should_yield_error=True,
@@ -160,14 +115,29 @@ dispatch_decorator_test_cases = {
                 @sngldsptchmthd
                 def foo(self, a):
                     print(a)
-
-                @foo.register
-                def _(self: "Foo", a: list) -> None:
-                    for idx, thing in enumerate(a):
-                        print(idx, thing)
             """
         ),
         should_yield_error=False,
         dispatch_decorators={"sngldsptchmthd"},
+    ),
+    "singledispatch_attribute_callable": DispatchDecoratorTestCase(
+        src=dedent(
+            """\
+            @functools.singledispatch()
+            def foo(a):
+                print(a)
+            """
+        ),
+        should_yield_error=False,
+    ),
+    "singledispatch_import_callable": DispatchDecoratorTestCase(
+        src=dedent(
+            """\
+            @singledispatch()
+            def foo(a):
+                print(a)
+            """
+        ),
+        should_yield_error=False,
     ),
 }

--- a/testing/test_cases/dispatch_decorator_test_cases.py
+++ b/testing/test_cases/dispatch_decorator_test_cases.py
@@ -1,0 +1,173 @@
+from textwrap import dedent
+from typing import AbstractSet, NamedTuple
+
+from flake8_annotations.checker import _DEFAULT_DISPATCH_DECORATORS
+
+
+class DispatchDecoratorTestCase(NamedTuple):
+    """Helper container for tests for the suppression of errors for dispatch decorators."""
+
+    src: str
+    should_yield_error: bool
+    dispatch_decorators: AbstractSet[str] = frozenset(_DEFAULT_DISPATCH_DECORATORS)
+
+
+dispatch_decorator_test_cases = {
+    "singledispatch_decorated_attribute": DispatchDecoratorTestCase(
+        src=dedent(
+            """\
+            @functools.singledispatch
+            def foo(a):
+                print(a)
+
+            @foo.register
+            def _(a: list) -> None:
+                for idx, thing in enumerate(a):
+                    print(idx, thing)
+            """
+        ),
+        should_yield_error=False,
+    ),
+    "singledispatch_decorated_aliased_attribute": DispatchDecoratorTestCase(
+        src=dedent(
+            """\
+            @fnctls.singledispatch
+            def foo(a):
+                print(a)
+
+            @foo.register
+            def _(a: list) -> None:
+                for idx, thing in enumerate(a):
+                    print(idx, thing)
+            """
+        ),
+        should_yield_error=False,
+    ),
+    "singledispatch_decorated_direct_import": DispatchDecoratorTestCase(
+        src=dedent(
+            """\
+            @singledispatch
+            def foo(a):
+                print(a)
+
+            @foo.register
+            def _(a: list) -> None:
+                for idx, thing in enumerate(a):
+                    print(idx, thing)
+            """
+        ),
+        should_yield_error=False,
+    ),
+    "singledispatch_decorated_aliased_import": DispatchDecoratorTestCase(
+        src=dedent(
+            """\
+            @sngldsptch
+            def foo(a):
+                print(a)
+
+            @foo.register
+            def _(a: list) -> None:
+                for idx, thing in enumerate(a):
+                    print(idx, thing)
+            """
+        ),
+        should_yield_error=True,
+    ),
+    "singledispatch_decorated_aliased_import_configured": DispatchDecoratorTestCase(
+        src=dedent(
+            """\
+            @sngldsptch
+            def foo(a):
+                print(a)
+
+            @foo.register
+            def _(a: list) -> None:
+                for idx, thing in enumerate(a):
+                    print(idx, thing)
+            """
+        ),
+        should_yield_error=False,
+        dispatch_decorators={"sngldsptch"},
+    ),
+    "singledispatchmethod_decorated_attribute": DispatchDecoratorTestCase(
+        src=dedent(
+            """\
+            class Foo:
+                @functools.singledispatchmethod
+                def foo(self, a):
+                    print(a)
+
+                @foo.register
+                def _(self: "Foo", a: list) -> None:
+                    for idx, thing in enumerate(a):
+                        print(idx, thing)
+            """
+        ),
+        should_yield_error=False,
+    ),
+    "singledispatchmethod_decorated_aliased_attribute": DispatchDecoratorTestCase(
+        src=dedent(
+            """\
+            class Foo:
+                @fnctls.singledispatchmethod
+                def foo(self, a):
+                    print(a)
+
+                @foo.register
+                def _(self: "Foo", a: list) -> None:
+                    for idx, thing in enumerate(a):
+                        print(idx, thing)
+            """
+        ),
+        should_yield_error=False,
+    ),
+    "singledispatchmethod_decorated_direct_import": DispatchDecoratorTestCase(
+        src=dedent(
+            """\
+            class Foo:
+                @singledispatchmethod
+                def foo(self, a):
+                    print(a)
+
+                @foo.register
+                def _(self: "Foo", a: list) -> None:
+                    for idx, thing in enumerate(a):
+                        print(idx, thing)
+            """
+        ),
+        should_yield_error=False,
+    ),
+    "singledispatchmethod_decorated_aliased_import": DispatchDecoratorTestCase(
+        src=dedent(
+            """\
+            class Foo:
+                @sngldsptchmthd
+                def foo(self, a):
+                    print(a)
+
+                @foo.register
+                def _(self: "Foo", a: list) -> None:
+                    for idx, thing in enumerate(a):
+                        print(idx, thing)
+            """
+        ),
+        should_yield_error=True,
+    ),
+    "singledispatchmethod_decorated_aliased_import_configured": DispatchDecoratorTestCase(
+        src=dedent(
+            """\
+            class Foo:
+                @sngldsptchmthd
+                def foo(self, a):
+                    print(a)
+
+                @foo.register
+                def _(self: "Foo", a: list) -> None:
+                    for idx, thing in enumerate(a):
+                        print(idx, thing)
+            """
+        ),
+        should_yield_error=False,
+        dispatch_decorators={"sngldsptchmthd"},
+    ),
+}

--- a/testing/test_cases/function_parsing_test_cases.py
+++ b/testing/test_cases/function_parsing_test_cases.py
@@ -534,7 +534,6 @@ function_test_cases = {
             nonclass_func(
                 name="foo",
                 function_type=FunctionType.PUBLIC,
-                is_overload_decorated=True,
             ),
         ),
     ),
@@ -550,7 +549,6 @@ function_test_cases = {
             nonclass_func(
                 name="foo",
                 function_type=FunctionType.PUBLIC,
-                is_overload_decorated=True,
             ),
         ),
     ),

--- a/testing/test_cases/function_parsing_test_cases.py
+++ b/testing/test_cases/function_parsing_test_cases.py
@@ -10,7 +10,7 @@ class FunctionTestCase(NamedTuple):
     """Helper container for Function parsing test cases."""
 
     src: str
-    func: Tuple[Function]
+    func: Tuple[Function, ...]
 
 
 # Note: For testing purposes, lineno and col_offset are ignored so these are set to dummy values

--- a/testing/test_cases/object_formatting_test_cases.py
+++ b/testing/test_cases/object_formatting_test_cases.py
@@ -15,7 +15,7 @@ class FormatTestCase(NamedTuple):
 
 # Define partial functions to simplify object creation
 arg = partial(Argument, lineno=0, col_offset=0, annotation_type=AnnotationType.ARGS)
-func = partial(Function, name="test_func", lineno=0, col_offset=0)
+func = partial(Function, name="test_func", lineno=0, col_offset=0, decorator_list=[])
 
 formatting_test_cases = {
     "arg": FormatTestCase(
@@ -47,8 +47,8 @@ formatting_test_cases = {
             "is_return_annotated=False, "
             "has_type_comment=False, "
             "has_only_none_returns=True, "
-            "is_overload_decorated=False, "
             "is_nested=False, "
+            "decorator_list=[], "
             "args=[Argument(argname='return', lineno=0, col_offset=0, annotation_type=AnnotationType.ARGS, "  # noqa: E501
             "has_type_annotation=False, has_3107_annotation=False, has_type_comment=False)]"
             ")"
@@ -68,8 +68,8 @@ formatting_test_cases = {
             "is_return_annotated=False, "
             "has_type_comment=False, "
             "has_only_none_returns=True, "
-            "is_overload_decorated=False, "
             "is_nested=False, "
+            "decorator_list=[], "
             "args=[Argument(argname='foo', lineno=0, col_offset=0, annotation_type=AnnotationType.ARGS, "  # noqa: E501
             "has_type_annotation=False, has_3107_annotation=False, has_type_comment=False), "
             "Argument(argname='return', lineno=0, col_offset=0, annotation_type=AnnotationType.ARGS, "  # noqa: E501

--- a/testing/test_cases/overload_decorator_test_cases.py
+++ b/testing/test_cases/overload_decorator_test_cases.py
@@ -1,5 +1,7 @@
 from textwrap import dedent
-from typing import NamedTuple
+from typing import AbstractSet, NamedTuple
+
+from flake8_annotations.checker import _DEFAULT_OVERLOAD_DECORATORS
 
 
 class OverloadDecoratorTestCase(NamedTuple):
@@ -7,6 +9,7 @@ class OverloadDecoratorTestCase(NamedTuple):
 
     src: str
     should_yield_error: bool
+    overload_decorators: AbstractSet[str] = frozenset(_DEFAULT_OVERLOAD_DECORATORS)
 
 
 overload_decorator_test_cases = {
@@ -49,7 +52,7 @@ overload_decorator_test_cases = {
         ),
         should_yield_error=False,
     ),
-    "overload_decorated_aliased_import": OverloadDecoratorTestCase(  # Aliased import not suppoerted
+    "overload_decorated_aliased_import": OverloadDecoratorTestCase(
         src=dedent(
             """\
             @ovrld
@@ -61,6 +64,22 @@ overload_decorator_test_cases = {
             """
         ),
         should_yield_error=True,
+    ),
+    "overload_decorated_aliased_import_configured": OverloadDecoratorTestCase(
+        src=dedent(
+            """\
+            @ovrld
+            def foo(a: int) -> int:
+                ...
+
+            def foo(a):
+                ...
+            """
+        ),
+        should_yield_error=False,
+        overload_decorators={
+            "ovrld",
+        },
     ),
     "overload_decorated_name_mismatch": OverloadDecoratorTestCase(
         src=dedent(

--- a/testing/test_cases/overload_decorator_test_cases.py
+++ b/testing/test_cases/overload_decorator_test_cases.py
@@ -92,4 +92,30 @@ overload_decorator_test_cases = {
         ),
         should_yield_error=True,
     ),
+    "overload_decorated_attribute_callable": OverloadDecoratorTestCase(
+        src=dedent(
+            """\
+            @typing.overload()
+            def foo(a: int) -> int:
+                ...
+
+            def foo(a):
+                ...
+            """
+        ),
+        should_yield_error=False,
+    ),
+    "overload_decorated_direct_import_callable": OverloadDecoratorTestCase(
+        src=dedent(
+            """\
+            @overload()
+            def foo(a: int) -> int:
+                ...
+
+            def foo(a):
+                ...
+            """
+        ),
+        should_yield_error=False,
+    ),
 }

--- a/testing/test_cases/overload_decorator_test_cases.py
+++ b/testing/test_cases/overload_decorator_test_cases.py
@@ -77,9 +77,7 @@ overload_decorator_test_cases = {
             """
         ),
         should_yield_error=False,
-        overload_decorators={
-            "ovrld",
-        },
+        overload_decorators={"ovrld"},
     ),
     "overload_decorated_name_mismatch": OverloadDecoratorTestCase(
         src=dedent(

--- a/testing/test_classifier.py
+++ b/testing/test_classifier.py
@@ -3,7 +3,7 @@ from typing import Tuple
 import pytest
 import pytest_check as check
 from flake8_annotations import Argument, Function
-from flake8_annotations.checker import classify_error
+from flake8_annotations.checker import FORMATTED_ERROR, classify_error
 from flake8_annotations.enums import AnnotationType
 from flake8_annotations.error_codes import Error
 from testing.helpers import check_source
@@ -100,7 +100,9 @@ class TestMixedTypeHintClassifier:
     """Test for correct classification of mixed type comments & type annotations."""
 
     @pytest.fixture(params=parser_test_cases.items(), ids=parser_test_cases.keys())
-    def yielded_errors(self, request) -> Tuple[str, ParserTestCase, Tuple[Error]]:  # noqa: ANN001
+    def yielded_errors(
+        self, request  # noqa: ANN001
+    ) -> Tuple[str, ParserTestCase, Tuple[FORMATTED_ERROR]]:
         """
         Build a fixture for the error codes emitted from parsing the type comments test code.
 
@@ -112,7 +114,7 @@ class TestMixedTypeHintClassifier:
         return test_case_name, test_case, tuple(check_source(test_case.src))
 
     def test_ANN301_classification(
-        self, yielded_errors: Tuple[str, ParserTestCase, Tuple[Error]]
+        self, yielded_errors: Tuple[str, ParserTestCase, Tuple[FORMATTED_ERROR]]
     ) -> None:
         """Test for correct classification of mixed type comments & type annotations."""
         failure_msg = f"Check failed for case '{yielded_errors[0]}'"
@@ -121,7 +123,7 @@ class TestMixedTypeHintClassifier:
         check.equal(yielded_errors[1].should_yield_ANN301, yielded_ANN301, msg=failure_msg)
 
     def test_single_ANN301_yield(
-        self, yielded_errors: Tuple[str, ParserTestCase, Tuple[Error]]
+        self, yielded_errors: Tuple[str, ParserTestCase, Tuple[FORMATTED_ERROR]]
     ) -> None:
         """Test that only one ANN301 error is yielded if a function mixes type comments."""
         if yielded_errors[1].should_yield_ANN301:

--- a/testing/test_dispatch_decorator.py
+++ b/testing/test_dispatch_decorator.py
@@ -1,0 +1,50 @@
+from typing import Tuple
+
+import pytest
+from flake8_annotations.error_codes import Error
+from testing.helpers import check_is_empty, check_is_not_empty, check_source
+
+from .test_cases.dispatch_decorator_test_cases import (
+    DispatchDecoratorTestCase,
+    dispatch_decorator_test_cases,
+)
+
+
+class TestDispatchDecoratorErrorSuppression:
+    """Test suppression of errors for the dispatch decorated functions."""
+
+    @pytest.fixture(
+        params=dispatch_decorator_test_cases.items(), ids=dispatch_decorator_test_cases.keys()
+    )
+    def yielded_errors(
+        self, request  # noqa: ANN001
+    ) -> Tuple[str, DispatchDecoratorTestCase, Tuple[Error]]:
+        """
+        Build a fixture for the errors emitted from parsing dispatch decorated test code.
+
+        Fixture provides a tuple of: test case name, its corresponding
+        `DispatchDecoratorTestCase` instance, and a tuple of the errors yielded by the
+        checker, which should be empty if the test case's `should_yield_error` is `False`.
+
+        To support decorator aliases, the `dispatch_decorators` param is optionally specified by the
+        test case. If none is explicitly set, the decorator list defaults to the checker's default.
+        """
+        test_case_name, test_case = request.param
+
+        return (
+            test_case_name,
+            test_case,
+            tuple(check_source(test_case.src, dispatch_decorators=test_case.dispatch_decorators)),
+        )
+
+    def test_dispatch_decorator_error_suppression(
+        self, yielded_errors: Tuple[str, DispatchDecoratorTestCase, Tuple[Error]]
+    ) -> None:
+        """Test that no errors are yielded dispatch decorated functions."""
+        test_case_name, test_case, errors = yielded_errors
+        failure_msg = f"Check failed for case '{test_case_name}'"
+
+        if test_case.should_yield_error:
+            check_is_not_empty(errors, msg=failure_msg)
+        else:
+            check_is_empty(errors, msg=failure_msg)

--- a/testing/test_dummy_arg_error_suppression.py
+++ b/testing/test_dummy_arg_error_suppression.py
@@ -2,7 +2,7 @@ from typing import Tuple
 
 import pytest
 import pytest_check as check
-from flake8_annotations.error_codes import Error
+from flake8_annotations.checker import FORMATTED_ERROR
 from testing.helpers import check_source
 
 from .test_cases.dummy_arg_suppress_test_cases import (
@@ -19,7 +19,7 @@ class TestDummyArgErrorSuppression:
     )
     def yielded_errors(
         self, request  # noqa: ANN001
-    ) -> Tuple[str, DummyArgSuppressionTestCase, Tuple[Error]]:
+    ) -> Tuple[str, DummyArgSuppressionTestCase, Tuple[FORMATTED_ERROR]]:
         """
         Build a fixture for the error codes emitted from parsing the dummy argument test code.
 
@@ -35,7 +35,7 @@ class TestDummyArgErrorSuppression:
         )
 
     def test_suppressed_return_error(
-        self, yielded_errors: Tuple[str, DummyArgSuppressionTestCase, Tuple[Error]]
+        self, yielded_errors: Tuple[str, DummyArgSuppressionTestCase, Tuple[FORMATTED_ERROR]]
     ) -> None:
         """Test that ANN000 level errors are suppressed if an annotation is named '_'."""
         failure_msg = f"Check failed for case '{yielded_errors[0]}'"

--- a/testing/test_mypy_init_return.py
+++ b/testing/test_mypy_init_return.py
@@ -2,7 +2,7 @@ from typing import Tuple
 
 import pytest
 import pytest_check as check
-from flake8_annotations.error_codes import Error
+from flake8_annotations.checker import FORMATTED_ERROR
 from testing.helpers import check_source
 
 from .test_cases.mypy_init_return_test_cases import (
@@ -17,7 +17,7 @@ class TestMypyStyleInitReturnErrorSuppression:
     @pytest.fixture(params=mypy_init_test_cases.items(), ids=mypy_init_test_cases.keys())
     def yielded_errors(
         self, request  # noqa: ANN001
-    ) -> Tuple[str, MypyInitReturnTestCase, Tuple[Error]]:
+    ) -> Tuple[str, MypyInitReturnTestCase, Tuple[FORMATTED_ERROR]]:
         """
         Build a fixture for the error codes emitted from parsing the Mypy __init__ return test code.
 
@@ -33,7 +33,7 @@ class TestMypyStyleInitReturnErrorSuppression:
         )
 
     def test_suppressed_return_error(
-        self, yielded_errors: Tuple[str, MypyInitReturnTestCase, Tuple[Error]]
+        self, yielded_errors: Tuple[str, MypyInitReturnTestCase, Tuple[FORMATTED_ERROR]]
     ) -> None:
         """
         Test that ANN200 level errors are suppressed in class __init__ according to Mypy's behavior.
@@ -44,5 +44,5 @@ class TestMypyStyleInitReturnErrorSuppression:
         test_case_name, test_case, errors = yielded_errors
         failure_msg = f"Check failed for case '{test_case_name}'"
 
-        yielded_ANN200 = any("ANN2" in error[2] for error in yielded_errors[2])
+        yielded_ANN200 = any("ANN2" in error[2] for error in errors)
         check.equal(test_case.should_yield_return_error, yielded_ANN200, msg=failure_msg)

--- a/testing/test_none_return_error_suppression.py
+++ b/testing/test_none_return_error_suppression.py
@@ -2,6 +2,7 @@ from typing import Tuple
 
 import pytest
 import pytest_check as check
+from flake8_annotations.checker import FORMATTED_ERROR
 from flake8_annotations.error_codes import Error
 from testing.helpers import check_source
 
@@ -35,7 +36,7 @@ class TestNoneReturnErrorSuppression:
         )
 
     def test_suppressed_return_error(
-        self, yielded_errors: Tuple[str, NoneReturnSuppressionTestCase, Tuple[Error]]
+        self, yielded_errors: Tuple[str, NoneReturnSuppressionTestCase, Tuple[FORMATTED_ERROR]]
     ) -> None:
         """Test that ANN200 level errors are suppressed if a function only returns None."""
         failure_msg = f"Check failed for case '{yielded_errors[0]}'"

--- a/testing/test_overload_decorator.py
+++ b/testing/test_overload_decorator.py
@@ -25,13 +25,16 @@ class TestOverloadDecoratorErrorSuppression:
         Fixture provides a tuple of: test case name, its corresponding
         `OverloadDecoratorTestCase` instance, and a tuple of the errors yielded by the
         checker, which should be empty if the test case's `should_yield_error` is `False`.
+
+        To support decorator aliases, the `overload_decorators` param is optionally specified by the
+        test case. If none is explicitly set, the decorator list defaults to the checker's default.
         """
         test_case_name, test_case = request.param
 
         return (
             test_case_name,
             test_case,
-            tuple(check_source(test_case.src)),
+            tuple(check_source(test_case.src, overload_decorators=test_case.overload_decorators)),
         )
 
     def test_overload_decorator_error_suppression(

--- a/testing/test_type_comment_arg_injection.py
+++ b/testing/test_type_comment_arg_injection.py
@@ -2,7 +2,7 @@ from typing import Tuple
 
 import pytest
 import pytest_check as check
-from flake8_annotations.error_codes import Error
+from flake8_annotations.checker import FORMATTED_ERROR
 from testing.helpers import check_source
 
 from .test_cases.type_comment_arg_injection_test_cases import (
@@ -20,7 +20,7 @@ class TestTypeCommentArgInject:
     )
     def yielded_errors(
         self, request  # noqa: ANN001
-    ) -> Tuple[str, TypeCommentArgInjectTestCase, Tuple[Error]]:
+    ) -> Tuple[str, TypeCommentArgInjectTestCase, Tuple[FORMATTED_ERROR]]:
         """
         Build a fixture for the error codes emitted from parsing the test code.
 
@@ -36,7 +36,7 @@ class TestTypeCommentArgInject:
         )
 
     def test_type_comment_arg_injection(
-        self, yielded_errors: Tuple[str, TypeCommentArgInjectTestCase, Tuple[Error]]
+        self, yielded_errors: Tuple[str, TypeCommentArgInjectTestCase, Tuple[FORMATTED_ERROR]]
     ) -> None:
         """Test that ANN100 errors are yielded appropriately for type comment annotated defs."""
         failure_msg = f"Check failed for case '{yielded_errors[0]}'"

--- a/testing/test_variable_formatting.py
+++ b/testing/test_variable_formatting.py
@@ -2,13 +2,12 @@ import re
 from typing import List, Tuple
 
 import pytest
-from flake8_annotations.checker import TypeHintChecker
+from flake8_annotations.checker import FORMATTED_ERROR
 from testing.helpers import check_source
 
 from .test_cases.variable_formatting_test_cases import variable_formatting_test_cases
 
 
-ERROR_CODE_TYPE = Tuple[int, int, str, TypeHintChecker]
 SIMPLE_ERROR_CODE = Tuple[str, str]
 
 # Error type specific matching patterns
@@ -16,7 +15,7 @@ TEST_ARG_NAMES = {"ANN001": "some_arg", "ANN002": "some_args", "ANN003": "some_k
 RE_DICT = {"ANN001": r"'(\w+)'", "ANN002": r"\*(\w+)", "ANN003": r"\*\*(\w+)"}
 
 
-def _simplify_error(error_code: ERROR_CODE_TYPE) -> SIMPLE_ERROR_CODE:
+def _simplify_error(error_code: FORMATTED_ERROR) -> SIMPLE_ERROR_CODE:
     """
     Simplify the error yielded by the flake8 checker into an (error type, argument name) tuple.
 


### PR DESCRIPTION
# Changelog
## [v2.6.0]
### Added
* #98 Add `--dispatch-decorators` to support suppression of all errors from functions decorated by decorators such as `functools.singledispatch` and `functools.singledispatchmethod`.
* #99 Add `--overload-decorators` to support generic aliasing of the `typing.overload` decorator.

### Fixed
* #106 Fix incorrect parsing of multiline docstrings with less than two lines of content, causing incorrect line numbers for yielded errors in Python versions prior to 3.8

# Additional Details
## Generic Functions
Per #98, the [`functools.singledispatch`](https://docs.python.org/3/library/functools.html#functools.singledispatch) and [`functools.singledispatchmethod`](https://docs.python.org/3/library/functools.html#functools.singledispatchmethod) decorators transform a function into a single-dispatch generic function.

For example:

```py
import functools

@functools.singledispatch
def foo(a):
    print(a)

@foo.register
def _(a: list) -> None:
    for idx, thing in enumerate(a):
        print(idx, thing)
```

Is correctly annotated but would previously yield linting errors for `foo`. In the spirit of the purpose of these decorators, linting errors are now suppressed for functions decorated with these decorators. The `--dispatch-decorators` configuration option has been added, which specifies a comma-separated list of decorators to be considered as dispatch decorators.

Decorators are matched based on their attribute name. For example, `"singledispatch"` will match any of the following:
  * `import functools; @functools.singledispatch`
  * `import functools as fnctls; @fnctls.singledispatch`
  * `from functools import singledispatch; @singledispatch`

By default, linting errors are suppressed for functions decorated by `singledispatch` or `singledispatchmethod`.

## `typing.overload` decorator aliasing
Per #99, handling of the [`typing.overload`](https://docs.python.org/3/library/typing.html#typing.overload) has been made generic, removing the caveat from the initial implementation. The `--overload-decorators` configuration option has been added, which specifies a comma-separated list of decorators to be considered as `typing.overload` decorators.

Decorators are now matched based on their attribute name. For example, `"overload"` will match any of the following:
  * `import typing; @typing.overload`
  * `import typing as t; @t.overload`
  * `from typing import overload; @overload`

By default, linting errors are suppressed for functions decorated by `overload`, which should be a transparent change from v2.4 (#97).


Closes #98
Closes #99
Closes #106