### PR TITLE
ANN402 Disallow bare builtins

### DIFF
--- a/flake8_annotations/ast_walker.py
+++ b/flake8_annotations/ast_walker.py
@@ -67,7 +67,7 @@ class Argument:
 
             if cls._is_annotated_any(node.annotation):
                 new_arg.is_dynamically_typed = True
-            
+
             if cls._is_bare_annotation(node.annotation):
                 new_arg.has_bare_annotation = True
 
@@ -77,10 +77,10 @@ class Argument:
 
             if cls._is_annotated_any(node.type_comment):
                 new_arg.is_dynamically_typed = True
-            
+
             if cls._is_bare_annotation(node.type_comment):
                 new_arg.has_bare_annotation = True
-        
+
         return new_arg
 
     @staticmethod
@@ -99,7 +99,17 @@ class Argument:
 
     @staticmethod
     def _is_bare_annotation(arg_expr: t.Union[ast.expr, str]) -> bool:
-        possibilities = ["dict", "list", "set", "frozenset", "defaultdict", "ordereddict", "chainmap", "counter", "deque"]
+        possibilities = [
+            "dict",
+            "list",
+            "set",
+            "frozenset",
+            "defaultdict",
+            "ordereddict",
+            "chainmap",
+            "counter",
+            "deque",
+        ]
         return any([Argument._is_annotated_with(possible, arg_expr) for possible in possibilities])
 
     @staticmethod
@@ -116,6 +126,7 @@ class Argument:
         `str`, and function-level type comments are assumed to be passed as `ast.expr`.
         """
         return Argument._is_annotated_with("Any", arg_expr)
+
 
 @define(slots=True)
 class Function:

--- a/flake8_annotations/error_codes.py
+++ b/flake8_annotations/error_codes.py
@@ -179,3 +179,11 @@ class ANN401(Error):
         self.argname = argname
         self.lineno = lineno
         self.col_offset = col_offset
+
+
+class ANN402(Error):
+    def __init__(self, argname: str, lineno: int, col_offset: int):
+        super().__init__("ANN402 Unparametrized generic builtins are disallowed")
+        self.argname = argname
+        self.lineno = lineno
+        self.col_offset = col_offset

--- a/testing/helpers.py
+++ b/testing/helpers.py
@@ -39,6 +39,7 @@ def check_source(
     allow_untyped_nested: bool = False,
     mypy_init_return: bool = False,
     allow_star_arg_any: bool = False,
+    allow_bare_types: bool = True,
     dispatch_decorators: t.AbstractSet[str] = frozenset(_DEFAULT_DISPATCH_DECORATORS),
     overload_decorators: t.AbstractSet[str] = frozenset(_DEFAULT_OVERLOAD_DECORATORS),
 ) -> t.Generator[FORMATTED_ERROR, None, None]:
@@ -53,6 +54,7 @@ def check_source(
     checker_instance.allow_untyped_nested = allow_untyped_nested
     checker_instance.mypy_init_return = mypy_init_return
     checker_instance.allow_star_arg_any = allow_star_arg_any
+    checker_instance.allow_bare_types = allow_bare_types
     checker_instance.dispatch_decorators = dispatch_decorators
     checker_instance.overload_decorators = overload_decorators
 


### PR DESCRIPTION
I've run aground of a use case where I'd like to ensure that I'm not just using bare builtins without relying on mypy.

I've not added any tests (but all extant tests pass) because I'm not sure I'm barking up the right implementation path. 

1) Is this sort of thing something that makes sense in this package?
2) Is there an implementation that's more consistent with the original patterns?

If you're happy including something like this, I'm happy to add tests.